### PR TITLE
Consertando bug do congelamento na 3a. rodada

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="me.chester.minitruco"
-    android:versionCode="20306"
-    android:versionName="2.3.6" >
+    android:versionCode="20305"
+    android:versionName="2.3.5" >
     <!-- Ao aumentar a versão, atualize também o versionCode
          e não esqueça do "novidades" em strings.xml" -->
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="me.chester.minitruco"
-    android:versionCode="20305"
-    android:versionName="2.3.5" >
+    android:versionCode="20307"
+    android:versionName="2.3.7" >
     <!-- Ao aumentar a versão, atualize também o versionCode
          e não esqueça do "novidades" em strings.xml" -->
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="me.chester.minitruco"
-    android:versionCode="20305"
-    android:versionName="2.3.5" >
+    android:versionCode="20306"
+    android:versionName="2.3.6" >
     <!-- Ao aumentar a versão, atualize também o versionCode
          e não esqueça do "novidades" em strings.xml" -->
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="me.chester.minitruco"
-    android:versionCode="20303"
-    android:versionName="2.3.3" >
+    android:versionCode="20305"
+    android:versionName="2.3.5" >
     <!-- Ao aumentar a versão, atualize também o versionCode
          e não esqueça do "novidades" em strings.xml" -->
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="me.chester.minitruco"
-    android:versionCode="20307"
-    android:versionName="2.3.7" >
+    android:versionCode="20308"
+    android:versionName="2.3.8" >
     <!-- Ao aumentar a versão, atualize também o versionCode
          e não esqueça do "novidades" em strings.xml" -->
 

--- a/app/src/main/java/me/chester/minitruco/android/MesaView.java
+++ b/app/src/main/java/me/chester/minitruco/android/MesaView.java
@@ -764,6 +764,12 @@ public class MesaView extends View {
 		desenhaBalao(canvas);
 		desenhaIndicadorDeVez(canvas);
 
+		if (trucoActivity.jogo.isJogoAutomatico()) {
+			jogaCarta(0);
+			jogaCarta(1);
+			jogaCarta(2);
+			respondePergunta(rand.nextBoolean());
+		}
 	}
 
 	private void desenhaBotao(String texto, Canvas canvas, RectF outerRect) {

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -99,6 +99,7 @@ public class TrucoActivity extends BaseActivity {
 			TextView tvEles = (TextView) findViewById(R.id.textview_eles);
 			Button btnAumento = (Button) findViewById(R.id.btnAumento);
 			Button btnAbertaFechada = (Button) findViewById(R.id.btnAbertaFechada);
+			Button btnNovaPartida = (Button) findViewById(R.id.btnNovaPartida);
 			switch (msg.what) {
 			case MSG_ATUALIZA_PLACAR:
 				if (placar[0] != msg.arg1) {
@@ -122,6 +123,9 @@ public class TrucoActivity extends BaseActivity {
 			case MSG_OFERECE_NOVA_PARTIDA:
 				if (jogo instanceof JogoLocal) {
 					layoutFimDeJogo.setVisibility(View.VISIBLE);
+					if (jogo.isJogoAutomatico()) {
+						btnNovaPartida.performClick();
+					}
 				}
 				break;
 			case MSG_REMOVE_NOVA_PARTIDA:
@@ -177,7 +181,8 @@ public class TrucoActivity extends BaseActivity {
 		boolean manilhaVelha = preferences.getBoolean("manilhaVelha", false)
 				&& !baralhoLimpo;
 		boolean humanoDecide = preferences.getBoolean("humanoDecide", true);
-		Jogo novoJogo = new JogoLocal(baralhoLimpo, manilhaVelha, tentoMineiro, humanoDecide);
+		boolean jogoAutomatico =  preferences.getBoolean("jogoAutomatico", false);
+		Jogo novoJogo = new JogoLocal(baralhoLimpo, manilhaVelha, tentoMineiro, humanoDecide, jogoAutomatico);
 		novoJogo.adiciona(jogadorHumano);
 		for (int i = 2; i <= 4; i++) {
 			novoJogo.adiciona(new JogadorCPU());

--- a/app/src/main/java/me/chester/minitruco/android/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/bluetooth/ServidorBluetoothActivity.java
@@ -327,7 +327,7 @@ public class ServidorBluetoothActivity extends BluetoothBaseActivity {
 
 	public Jogo _criaNovoJogo(JogadorHumano jogadorHumano) {
 		Jogo jogo = new JogoLocal(regras.charAt(0) == 'T',
-				regras.charAt(1) == 'T', false, false);
+				regras.charAt(1) == 'T', false, false, false);
 		jogo.adiciona(jogadorHumano);
 		for (int i = 0; i <= 2; i++) {
 			if (connClientes[i] != null) {

--- a/app/src/main/java/me/chester/minitruco/core/JogadorCPU.java
+++ b/app/src/main/java/me/chester/minitruco/core/JogadorCPU.java
@@ -129,21 +129,6 @@ public class JogadorCPU extends Jogador implements Runnable {
 		}
 	}
 
-	private class AumentoApostaRunner implements Runnable {
-		private final Jogo jogo;
-		private final Jogador jogador;
-
-		public AumentoApostaRunner(Jogo jogo, Jogador jogador) {
-			this.jogo = jogo;
-			this.jogador = jogador;
-		}
-
-		@Override
-		public void run() {
-			jogo.aumentaAposta(jogador);
-		}
-	}
-
 	public void run() {
 
 		Log.i("JogadorCPU", "JogadorCPU " + this + " (.run) iniciado");
@@ -175,14 +160,18 @@ public class JogadorCPU extends Jogador implements Runnable {
 				// Se a estratégia pediu truco, processa e desencana de jogar
 				// agora
 				if ((posCarta == -1) && (situacaoJogo.valorProximaAposta != 0)) {
+					// Faz a
+					// solicitação de truco numa nova thread // (usando o
+					// próprio
+					// JogadorCPU como Runnable - era uma inner // class, mas
+					// otimizei para reduzir o .jar)
 					aceitaramTruco = false;
 					numRespostasAguardando = 2;
 					Log.i("JogadorCPU", "Jogador " + this.getPosicao()
 							+ " vai aumentar aposta");
 					minhaVez = true;
 					estouAguardandoRepostaAumento = true;
-					Thread t = new Thread(new AumentoApostaRunner(jogo, this));
-					t.start();
+					jogo.aumentaAposta(this);
 					Log.i("JogadorCPU", "Jogador " + this.getPosicao()
 							+ " aguardando resposta");
 					continue;

--- a/app/src/main/java/me/chester/minitruco/core/JogadorCPU.java
+++ b/app/src/main/java/me/chester/minitruco/core/JogadorCPU.java
@@ -129,6 +129,21 @@ public class JogadorCPU extends Jogador implements Runnable {
 		}
 	}
 
+	private class AumentoApostaRunner implements Runnable {
+		private final Jogo jogo;
+		private final Jogador jogador;
+
+		public AumentoApostaRunner(Jogo jogo, Jogador jogador) {
+			this.jogo = jogo;
+			this.jogador = jogador;
+		}
+
+		@Override
+		public void run() {
+			jogo.aumentaAposta(jogador);
+		}
+	}
+
 	public void run() {
 
 		Log.i("JogadorCPU", "JogadorCPU " + this + " (.run) iniciado");
@@ -160,18 +175,14 @@ public class JogadorCPU extends Jogador implements Runnable {
 				// Se a estratégia pediu truco, processa e desencana de jogar
 				// agora
 				if ((posCarta == -1) && (situacaoJogo.valorProximaAposta != 0)) {
-					// Faz a
-					// solicitação de truco numa nova thread // (usando o
-					// próprio
-					// JogadorCPU como Runnable - era uma inner // class, mas
-					// otimizei para reduzir o .jar)
 					aceitaramTruco = false;
 					numRespostasAguardando = 2;
 					Log.i("JogadorCPU", "Jogador " + this.getPosicao()
 							+ " vai aumentar aposta");
 					minhaVez = true;
 					estouAguardandoRepostaAumento = true;
-					jogo.aumentaAposta(this);
+					Thread t = new Thread(new AumentoApostaRunner(jogo, this));
+					t.start();
 					Log.i("JogadorCPU", "Jogador " + this.getPosicao()
 							+ " aguardando resposta");
 					continue;

--- a/app/src/main/java/me/chester/minitruco/core/JogadorCPU.java
+++ b/app/src/main/java/me/chester/minitruco/core/JogadorCPU.java
@@ -136,8 +136,6 @@ public class JogadorCPU extends Jogador implements Runnable {
 			sleep(100);
 
 			if (minhaVez && !estouAguardandoRepostaAumento) {
-
-				minhaVez = false;
 				Log.i("JogadorCPU", "Jogador " + this.getPosicao()
 						+ " viu que e' sua vez");
 
@@ -169,7 +167,6 @@ public class JogadorCPU extends Jogador implements Runnable {
 					numRespostasAguardando = 2;
 					Log.i("JogadorCPU", "Jogador " + this.getPosicao()
 							+ " vai aumentar aposta");
-					minhaVez = true;
 					estouAguardandoRepostaAumento = true;
 					jogo.aumentaAposta(this);
 					Log.i("JogadorCPU", "Jogador " + this.getPosicao()
@@ -180,12 +177,16 @@ public class JogadorCPU extends Jogador implements Runnable {
 				// Se a estratégia pediu truco fora de hora, ignora e joga a
 				// primeira carta
 				if (posCarta == -1) {
+					Log.i("JogadorCPU", "Jogador" + this.getPosicao()
+							+ " pediu truco fora de hora");
 					posCarta = 0;
 				}
 
 				// Joga a carta selecionada e remove ela da mão
 				boolean isFechada = posCarta >= 10;
 				if (isFechada) {
+					Log.i("JogadorCPU", "Jogador" + this.getPosicao()
+							+ " vai tentar jogar fechada");
 					posCarta -= 10;
 				}
 
@@ -198,14 +199,24 @@ public class JogadorCPU extends Jogador implements Runnable {
 					// chega aqui com 0 elementos no array, mas vamos evitar o crash
 					// e ver se tudo se resolve sozinho; não deve afetar quem
 					// não tem o problema (como eu)
+					Log.i("JogadorCPU", "Out Of Bounds tentando recuperar a carta de cartasRestantes", e);
 					continue;
 				}
 				c.setFechada(isFechada && podeFechada);
 				cartasRestantes.removeElement(c);
+				if (!minhaVez) {
+					// Isso acontece MUITO raramente, mas trava o jogo; na dúvida,
+					// a gente seta o minhaVez para false no maoFechada() e
+					// evita esse problema aqui
+					// TODO: deixar rodando e ver se chega aqui, ou se setar pra false no maoFechada resolveu
+					Log.i("Jogador CPU", "Jogador " + this.getPosicao()
+						+ "IA pedir para jogar " + c + ", mas acabou a mão/rodada");
+					continue;
+				}
 				Log.i("JogadorCPU", "Jogador " + this.getPosicao()
-						+ " vai pedir para jogar " + c);
+						+ " (" + this.estrategia.getNomeEstrategia() + ") vai pedir para jogar " + c);
 				jogo.jogaCarta(this, c);
-
+				minhaVez = false;
 			}
 
 			if (recebiPedidoDeAumento) {
@@ -354,7 +365,15 @@ public class JogadorCPU extends Jogador implements Runnable {
 	}
 
 	public void maoFechada(int[] pontosEquipe) {
-		// Não faz nada
+
+		Log.i("JogadorCPU", "Jogador " + this.getPosicao()
+		+ " recebeu notificação de mão fechada; mudando minhaVez de " + minhaVez + "para false");
+
+		// Cancela todas as jogadas em aguardo
+		minhaVez = false;
+		estouAguardandoRepostaAumento = false;
+		recebiPedidoDeAumento = false;
+		recebiPedidoDeAumento = false;
 	}
 
 	public void jogoFechado(int numEquipeVencedora) {

--- a/app/src/main/java/me/chester/minitruco/core/JogadorCPU.java
+++ b/app/src/main/java/me/chester/minitruco/core/JogadorCPU.java
@@ -125,6 +125,7 @@ public class JogadorCPU extends Jogador implements Runnable {
 					+ " recebeu notificacao de vez");
 			this.podeFechada = podeFechada;
 			this.minhaVez = true;
+			this.estouAguardandoRepostaAumento = false;
 		}
 	}
 
@@ -134,18 +135,14 @@ public class JogadorCPU extends Jogador implements Runnable {
 		while (jogo == null || !jogo.jogoFinalizado) {
 			sleep(100);
 
-			if (minhaVez) {
+			if (minhaVez && !estouAguardandoRepostaAumento) {
 
 				minhaVez = false;
 				Log.i("JogadorCPU", "Jogador " + this.getPosicao()
 						+ " viu que e' sua vez");
 
 				// Dá um tempinho, pra fingir que está "pensando"
-				try {
-					Thread.sleep(random.nextInt(250) + 200);
-				} catch (InterruptedException e) {
-					// Nada, apenas timing...
-				}
+				sleep(random.nextInt(250) + 200);
 
 				// Atualiza a situação do jogo (incluindo as cartas na mão)
 				atualizaSituacaoJogo();
@@ -172,6 +169,7 @@ public class JogadorCPU extends Jogador implements Runnable {
 					numRespostasAguardando = 2;
 					Log.i("JogadorCPU", "Jogador " + this.getPosicao()
 							+ " vai aumentar aposta");
+					minhaVez = true;
 					estouAguardandoRepostaAumento = true;
 					jogo.aumentaAposta(this);
 					Log.i("JogadorCPU", "Jogador " + this.getPosicao()

--- a/app/src/main/java/me/chester/minitruco/core/Jogo.java
+++ b/app/src/main/java/me/chester/minitruco/core/Jogo.java
@@ -369,4 +369,13 @@ public abstract class Jogo implements Runnable {
 		}
 	}
 
+	/**
+	 * Configuração que faz o jogador humano jogar automaticamente
+	 *
+	 * @return false (a não ser em JogoLocal _se_ a opção for habilitada)
+	 */
+	public boolean isJogoAutomatico() {
+		return false;
+	}
+
 }

--- a/app/src/main/java/me/chester/minitruco/core/JogoLocal.java
+++ b/app/src/main/java/me/chester/minitruco/core/JogoLocal.java
@@ -178,6 +178,7 @@ public class JogoLocal extends Jogo {
 				sleep();
 			}
 			if (!jogoFinalizado) {
+				Log.i("Jogo", "alguém jogou!");
 				processaJogada();
 				alguemJogou = false;
 			}
@@ -267,6 +268,11 @@ public class JogoLocal extends Jogo {
 		Jogador j = this.jogadorQueJogou;
 		Carta c = this.cartaJogada;
 
+		Log.i("JogoLocal", "processaJogada: j" + j.getPosicao() + " joga " + c +
+				"; jogadorPedindoAumento:" + (jogadorPedindoAumento == null ? "null" : jogadorPedindoAumento.getPosicao()) +
+				"; isAguardandoRespostaMao11:" + isAguardandoRespostaMao11() +
+				"; jogadorDaVez: "+getJogadorDaVez().getPosicao());
+
 		// Se o jogo acabou, a mesa não estiver completa, já houver alguém
 		// trucando, estivermos aguardando ok da mão de 11 ou não for a vez do
 		// cara, recusa
@@ -281,9 +287,25 @@ public class JogoLocal extends Jogo {
 		for (int i = 0; i <= 2; i++) {
 			for (int k = 0; k <= 3; k++) {
 				if (c.equals(cartasJogadasPorRodada[i][k])) {
+					Log.i("JogoLocal", "carta jogada anteriormente: "+ c + "," + i + "," + k);
+					renotificaVezCPU();
 					return;
 				}
 			}
+		}
+
+		// Verifica se a carta realmente pertence ao jogador
+		Carta cartaNaMaoDoJogador = null;
+		for (int i = 0; i <= 2; i++) {
+			if (j.getCartas()[i].equals(c)) {
+				cartaNaMaoDoJogador = c;
+			}
+		}
+		if (cartaNaMaoDoJogador == null) {
+			Log.i("JogoLocal", "j" + j.getPosicao() + " tentou jogar " + c +
+					" mas esta carta não está na mão dele");
+			renotificaVezCPU();
+			return;
 		}
 
 		// Garante que a regra para carta fechada seja respeitada
@@ -638,6 +660,21 @@ public class JogoLocal extends Jogo {
 			interessado.vez(j, pf);
 		}
 
+	}
+
+	/**
+	 * Se o jogador da vez for CPU, re-notifica ele que é sua vez.
+	 *
+	 * Isso é usado para casos em que a CPU joga uma jogada inválida (ex.: porque
+	 * jogou depois que a mão fechou), evitando que ela fique "travada"
+	 */
+	private void renotificaVezCPU() {
+		Jogador j = getJogadorDaVez();
+		boolean pf = isPodeFechada();
+
+		if (j instanceof JogadorCPU) {
+			j.vez(j, pf);
+		}
 	}
 
 	/**

--- a/app/src/main/java/me/chester/minitruco/core/JogoLocal.java
+++ b/app/src/main/java/me/chester/minitruco/core/JogoLocal.java
@@ -70,7 +70,7 @@ public class JogoLocal extends Jogo {
 	 *            completo (sujo)
 	 */
 	public JogoLocal(boolean baralhoLimpo, boolean manilhaVelha,
-			boolean tentoMineiro, boolean humanoDecide) {
+			boolean tentoMineiro, boolean humanoDecide, boolean jogoAutomatico) {
 		this.manilhaVelha = manilhaVelha;
 		this.baralhoLimpo = baralhoLimpo;
 		if (tentoMineiro && manilhaVelha)
@@ -79,6 +79,7 @@ public class JogoLocal extends Jogo {
 			this.tento = new TentoPaulista();
 		this.baralho = new Baralho(baralhoLimpo);
 		this.humanoDecide = humanoDecide;
+        this.jogoAutomatico = jogoAutomatico;
 	}
 
 	/**
@@ -155,6 +156,7 @@ public class JogoLocal extends Jogo {
 	private final boolean manilhaVelha;
 	private final boolean baralhoLimpo;
 	private final boolean humanoDecide;
+    private final boolean jogoAutomatico;
 
 	/*
 	 * (non-Javadoc)
@@ -781,6 +783,11 @@ public class JogoLocal extends Jogo {
 		} catch (InterruptedException e) {
 			e.printStackTrace();
 		}
+	}
+
+	@Override
+	public boolean isJogoAutomatico() {
+		return jogoAutomatico;
 	}
 
 }

--- a/app/src/main/java/me/chester/minitruco/core/JogoLocal.java
+++ b/app/src/main/java/me/chester/minitruco/core/JogoLocal.java
@@ -560,11 +560,12 @@ public class JogoLocal extends Jogo {
 				interessado.aceitouAumentoAposta(j, valorMao);
 			}
 		} else {
-			// Primeiro notifica todo mundo (ou só o humano, se for um aceite ignorado)
-			if (ignorarAceite) {
-				jogadores[posParceiro - 1].aceitouAumentoAposta(j, valorMao);
-			} else {
-				for (Jogador interessado : jogadores) {
+			// Primeiro notifica todo mundo da recusa
+			// (se for um aceite ignorado, diz pro humano que aceitou, só pra ele saber o que seria feito)
+			for (Jogador interessado : jogadores) {
+				if (aceitou && ignorarAceite && (interessado == jogadores[posParceiro - 1])) {
+					interessado.aceitouAumentoAposta(j, valorMao);
+				} else {
 					interessado.recusouAumentoAposta(j);
 				}
 			}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,7 +156,7 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
-            Solução adicional para congelamento do jogo na 3a. jogada.
+            Corrige congelamento do jogo na 3a. jogada.
         ]]>
     </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,9 +156,7 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
-            Tentando corrigir fechamento na 3a. rodada em alguns celulares.
-            <br/>
-            Me mande um e-mail (cd@pobox.com) se isso ainda acontece com você e quiser me ajudar a resolver. Obrigado!
+            Corrige congelamento do jogo na 3a. jogada.
         ]]>
     </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,7 +156,9 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
-            Corrige congelamento do jogo na 3a. jogada.
+            Mais uma tentativa de corrigir os congelamentos do jogo quando o jogador está no controle do aceite.
+            <br/><br/>
+            Eu sei, é a terceira; mas eu não consigo reproduzir aqui; peço a compreensão das pessoas afetadas! Se quiser me ajudar a testar, entre no "Programa Beta" da loja do Google e você receberá atualizações dessas versões de teste antes das outras pessoas; me mande email se tiver dúvidas (endereço no título). Grato.
         ]]>
     </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,9 +156,8 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
-            Mais uma tentativa de corrigir os congelamentos do jogo quando o jogador está no controle do aceite.
-            <br/><br/>
-            Eu sei, é a terceira; mas eu não consigo reproduzir aqui; peço a compreensão das pessoas afetadas! Se quiser me ajudar a testar, entre no "Programa Beta" da loja do Google e você receberá atualizações dessas versões de teste antes das outras pessoas; me mande email se tiver dúvidas (endereço no título). Grato.
+            - Correção final do congelamento (🤞 - ficou 12h jogando sozinho sem congelar)<br/>
+            - Opção de deixar o celular jogar sozinho (para ajudar desenvolvedor com problemas como este)
         ]]>
     </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,7 +156,7 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
-            Corrige congelamento do jogo na 3a. jogada.
+            Solução adicional para congelamento do jogo na 3a. jogada.
         ]]>
     </string>
 

--- a/app/src/main/res/xml/opcoes.xml
+++ b/app/src/main/res/xml/opcoes.xml
@@ -8,4 +8,7 @@
 		android:key="manilhaVelha" android:disableDependentsState="false"/>
 	<CheckBoxPreference android:title="Tento Mineiro" android:key="tentoMineiro" android:dependency="manilhaVelha" android:defaultValue="false" android:summary="Usa os valores 2, 4, 6, 8, 10, 12 (só vale com manilha velha)"/>
 	<CheckBoxPreference android:title="Aumento/mão de 11 decidido pelo jogador" android:key="humanoDecide" android:defaultValue="true" android:summary="Em jogo local, se esta opção estiver ligada, o parceiro virtual não pode aceitar truco ou mão de 11 (ele só diz se iria)."/>
+	<PreferenceCategory android:title="Desenvolvimento/Depuração (não mexa a não ser que saiba o que está fazendo)">
+		<CheckBoxPreference android:title="Jogo Automático" android:key="jogoAutomatico" android:defaultValue="false" android:summary="Joga uma carta ou pede truco automaticamente (e aleatoriamente) apenas em jogo local."/>
+	</PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Causa: o status de `minhaVez` não é setado para `true` quando o celular não dá o sleep apropriado após um pedido de truco (a resposta de um jogador chega antes da configuração do outro)

Como reproduzir: desabilitar o sleep no JogadorCPU; qualquer pedido de truco por uma CPU vai congelar ali

Conserto: ao invés de contar com as threads para restaurar o `minhaVez`, mantém ele em `true` enquanto estiver aguardando truco, mas também checa `estouAguardandoRespostaAumento` (e zera este quando recebe a notifição de vez do jogador atual)