### PR TITLE
v2.3.9 - Bluetooth e ajustes visuais

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,16 +5,8 @@ android {
 
     defaultConfig {
         applicationId "me.chester.minitruco"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 33
-    }
-
-    dependencies {
-        implementation 'androidx.appcompat:appcompat:1.5.1'
-        implementation 'androidx.activity:activity:1.6.1'
-        implementation 'androidx.fragment:fragment:1.5.5'
-
-        implementation project(path: ':core')
     }
 
     buildTypes {
@@ -23,4 +15,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+
+    implementation project(path: ':core')
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
 
     <application
         android:icon="@drawable/icon"
-        android:label="@string/app_name" >
+        android:label="@string/app_name"
+        android:theme="@style/miniTrucoTheme" >
         <activity
             android:name=".android.TituloActivity"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="me.chester.minitruco"
-    android:versionCode="20308"
-    android:versionName="2.3.8" >
+    android:versionCode="20309"
+    android:versionName="2.3.9" >
     <!-- Ao aumentar a versão, atualize também o versionCode
          e não esqueça do "novidades" em strings.xml" -->
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <!-- Bluetooth game -->
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
 

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -60,6 +60,12 @@ public class TituloActivity extends BaseActivity {
 		findViewById(R.id.btnBluetooth).setVisibility(mostrarMenuBluetooth ? View.VISIBLE : View.GONE);
 	}
 
+	private void botoesHabilitados(boolean status) {
+		findViewById(R.id.btnJogar).setActivated(status);
+		findViewById(R.id.btnBluetooth).setActivated(status);
+		findViewById(R.id.btnOpcoes).setActivated(status);
+	}
+
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
 		super.onCreateOptionsMenu(menu);
@@ -88,8 +94,10 @@ public class TituloActivity extends BaseActivity {
 	}
 
 	private void perguntaCriarOuProcurarBluetooth() {
+		botoesHabilitados(false);
 		OnClickListener listener = new OnClickListener() {
 			public void onClick(DialogInterface dialog, int which) {
+				botoesHabilitados(true);
 				switch (which) {
 				case AlertDialog.BUTTON_NEGATIVE:
 					startActivity(new Intent(TituloActivity.this,

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -1,25 +1,18 @@
 package me.chester.minitruco.android;
 
-import android.Manifest;
 import android.app.AlertDialog;
 import android.bluetooth.BluetoothAdapter;
 import android.content.DialogInterface;
-import android.content.DialogInterface.OnCancelListener;
 import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-
-import androidx.annotation.NonNull;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 
 import me.chester.minitruco.BuildConfig;
 import me.chester.minitruco.R;
@@ -35,14 +28,6 @@ import me.chester.minitruco.android.bluetooth.ServidorBluetoothActivity;
  */
 public class TituloActivity extends BaseActivity {
 
-	public static final String[] BLUETOOTH_PERMISSIONS = new String[] {
-		// Permissões que nem deveriam estar aqui, vide callback abaixo
-		Manifest.permission.BLUETOOTH,
-		Manifest.permission.BLUETOOTH_ADMIN,
-		// Permissões runtime
-		Manifest.permission.BLUETOOTH_CONNECT,
-		Manifest.permission.BLUETOOTH_SCAN
-	};
 	SharedPreferences preferences;
 	Boolean mostrarMenuBluetooth;
 
@@ -102,34 +87,6 @@ public class TituloActivity extends BaseActivity {
 		return super.onOptionsItemSelected(item);
 	}
 
-	private boolean verificaEPedePermissoesDeBluetooth(){
-		if (ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED &&
-			ContextCompat.checkSelfPermission(this,Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED) {
-			return true;
-		} else {
-			ActivityCompat.requestPermissions(this, BLUETOOTH_PERMISSIONS, 1);
-			return false;
-		}
-	}
-
-	@Override
-	public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-		super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-		if (requestCode == 1) {
-			// Normalmente a gente só pediria as duas permissões novas e checaria se foi dado grant
-			// aqui; mas alguns aparelhos (mesmo com Android relativamente novo) simplesmente pulam
-			// a fase de perguntar, então eu resolvi pular a checagem aqui, porque das três uma:
-			// - Pessoa autorizou; vai dar tudo certo
-			// - Pergunta não foi feita; vai dar tudo certo (as permissões básicas aparecem)
-			// - Pessoa não autorizou (mesmo depois de clicar o botão Bluetooth): vai crashar,
-			//   e eu não me importo. Como você quer jogar no Bluetooth sem Bluetooth? Abre a app
-			//   e tenta de novo.
-			//			if (grantResults.length == 2 && grantResults[0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
-				perguntaCriarOuProcurarBluetooth();
-			//			}
-		}
-	}
-
 	private void perguntaCriarOuProcurarBluetooth() {
 		OnClickListener listener = new OnClickListener() {
 			public void onClick(DialogInterface dialog, int which) {
@@ -157,9 +114,7 @@ public class TituloActivity extends BaseActivity {
 	}
 
 	public void bluetoothButtonClickHandler(View v) {
-		if (verificaEPedePermissoesDeBluetooth()) {
-			perguntaCriarOuProcurarBluetooth();
-		}
+		perguntaCriarOuProcurarBluetooth();
 	}
 
 	public void opcoesButtonClickHandler(View v) {

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -7,6 +7,7 @@ import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.view.Menu;
@@ -135,5 +136,12 @@ public class TituloActivity extends BaseActivity {
 	@Override
 	protected void onResume() {
 		super.onResume();
+	}
+
+	@Override
+	public void onBackPressed() {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+			this.finishAndRemoveTask();
+		}
 	}
 }

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -91,11 +91,11 @@ public class TituloActivity extends BaseActivity {
 		OnClickListener listener = new OnClickListener() {
 			public void onClick(DialogInterface dialog, int which) {
 				switch (which) {
-				case AlertDialog.BUTTON_POSITIVE:
+				case AlertDialog.BUTTON_NEGATIVE:
 					startActivity(new Intent(TituloActivity.this,
 							ServidorBluetoothActivity.class));
 					break;
-				case AlertDialog.BUTTON_NEGATIVE:
+				case AlertDialog.BUTTON_POSITIVE:
 					startActivity(new Intent(TituloActivity.this,
 							ClienteBluetoothActivity.class));
 					break;
@@ -103,8 +103,9 @@ public class TituloActivity extends BaseActivity {
 			}
 		};
 		new AlertDialog.Builder(this).setTitle("Bluetooth")
-				.setPositiveButton("Criar Jogo", listener)
-				.setNegativeButton("Procurar Jogo", listener)
+				.setMessage("Para jogar via Bluetooth, um celular deve criar o jogo e os outros devem procurá-lo.\n\nCertifique-se de que todos os celulares estejam pareados com o celular que criar o jogo.")
+				.setNegativeButton("Criar Jogo", listener)
+				.setPositiveButton("Procurar Jogo", listener)
 				.show();
 	}
 

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -1,5 +1,7 @@
 package me.chester.minitruco.android;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Color;
@@ -217,6 +219,17 @@ public class TrucoActivity extends BaseActivity {
 		if (!jogoAbortado) {
 			jogo.abortaJogo(1);
 		}
+	}
+
+	@Override
+	public void onBackPressed() {
+		new AlertDialog.Builder(this)
+			.setIcon(android.R.drawable.ic_dialog_alert)
+			.setTitle("Encerrar")
+			.setMessage("Você quer mesmo encerrar este jogo?")
+			.setPositiveButton("Sim", (dialog, which) -> finish())
+			.setNegativeButton("Não", null)
+			.show();
 	}
 
 	public static boolean isViva() {

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -74,8 +74,8 @@ public class TrucoActivity extends BaseActivity {
 				if (placar[1] != msg.arg2) {
 					tvEles.setBackgroundColor(Color.YELLOW);
 				}
-				tvNos.setText("Nós: " + msg.arg1);
-				tvEles.setText("Eles: " + msg.arg2);
+				tvNos.setText(msg.arg1 + " 👇");
+				tvEles.setText("👆 " + msg.arg2);
 				placar[0] = msg.arg1;
 				placar[1] = msg.arg2;
 				break;

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -37,8 +37,6 @@ public class TrucoActivity extends BaseActivity {
 			"NOVE!", "DOZE!!!" };
 
 	private MesaView mesa;
-	private TextView textViewAnuncio;
-	private View layoutAnuncio;
 	private View layoutFimDeJogo;
 	private static boolean mIsViva = false;
 	boolean jogoAbortado = false;
@@ -57,7 +55,6 @@ public class TrucoActivity extends BaseActivity {
 	static final int MSG_ESCONDE_BOTAO_AUMENTO = 5;
 	static final int MSG_MOSTRA_BOTAO_ABERTA_FECHADA = 6;
 	static final int MSG_ESCONDE_BOTAO_ABERTA_FECHADA = 7;
-	static final int MSG_ESCONDE_PATROCINIO = 8;
 
 	Handler handler = new Handler() {
 		public void handleMessage(Message msg) {
@@ -82,9 +79,6 @@ public class TrucoActivity extends BaseActivity {
 			case MSG_TIRA_DESTAQUE_PLACAR:
 				tvNos.setBackgroundColor(Color.TRANSPARENT);
 				tvEles.setBackgroundColor(Color.TRANSPARENT);
-				break;
-			case MSG_ESCONDE_PATROCINIO:
-				layoutAnuncio.setVisibility(View.INVISIBLE);
 				break;
 			case MSG_OFERECE_NOVA_PARTIDA:
 				if (jogo instanceof JogoLocal) {
@@ -186,7 +180,9 @@ public class TrucoActivity extends BaseActivity {
 	}
 
 	public void aumentoClickHandler(View v) {
-		handler.sendMessage(Message.obtain(handler, MSG_ESCONDE_BOTAO_AUMENTO));
+		// Não usamos o handler aqui para reduzir a chance da pessoa
+		// fazer uma acionamento duplo (e duplicar o aumento)
+		findViewById(R.id.btnAumento).setVisibility(Button.GONE);
 		mesa.setStatusVez(MesaView.STATUS_VEZ_HUMANO_AGUARDANDO);
 		jogo.aumentaAposta(jogadorHumano);
 	}

--- a/app/src/main/java/me/chester/minitruco/android/bluetooth/BluetoothBaseActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/bluetooth/BluetoothBaseActivity.java
@@ -14,7 +14,6 @@ import android.os.Message;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -51,7 +50,7 @@ public abstract class BluetoothBaseActivity extends BaseActivity implements
 			BLUETOOTH_PERMISSIONS = new String[] {
 					Manifest.permission.BLUETOOTH_CONNECT,
 					Manifest.permission.BLUETOOTH_SCAN,
-					Manifest.permission.BLUETOOTH_ADVERTISE
+					Manifest.permission.BLUETOOTH_ADVERTISE,
 			};
 		}
 	};
@@ -152,8 +151,7 @@ public abstract class BluetoothBaseActivity extends BaseActivity implements
 							iniciaAtividadeBluetooth();
 						}
 					} else {
-						Toast.makeText(this, "Permissão Bluetooth negada. Se persistir, tente autorizar nas configs do celular ou desinstalar/reinstalar o jogo.", Toast.LENGTH_LONG).show();
-						finish();
+						msgErroFatal("Permissão Bluetooth negada. Se o problema persistir, tente autorizar nas configs do celular ou desinstalar/reinstalar o jogo.");
 					}
 				});
 

--- a/app/src/main/java/me/chester/minitruco/android/bluetooth/ClienteBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/bluetooth/ClienteBluetoothActivity.java
@@ -33,6 +33,8 @@ public class ClienteBluetoothActivity extends BluetoothBaseActivity implements
 	private static ClienteBluetoothActivity currentInstance;
 
 	private List<BluetoothDevice> dispositivosPareados;
+	private BluetoothDevice servidor;
+
 	private Thread threadConexao;
 	private Thread threadMonitoraConexao;
 	private JogoBluetooth jogo;
@@ -84,6 +86,9 @@ public class ClienteBluetoothActivity extends BluetoothBaseActivity implements
 	}
 
 	public void run() {
+		if (!conectaNoServidor()) {
+			return;
+		}
 		atualizaDisplay();
 
 		if (socket == null) {
@@ -275,35 +280,29 @@ public class ClienteBluetoothActivity extends BluetoothBaseActivity implements
         return true;
     }
 
-    /**
-     * Tenta conectar no servidor recebido e, caso consiga, inicia o jogo
-     *
-     * @param device Servidor do Mni Truco
-     */
-    private void conectaNoServidor(BluetoothDevice device) {
-        try {
+    private boolean conectaNoServidor() {
+		String nomeDoServidor = servidor.getName();
+		try {
 			LOGGER.log(Level.INFO, "Criando socket");
 			LOGGER.log(Level.INFO, "device.getName()");
-            setMensagem("Consultando " + device.getName());
-            socket = device.createRfcommSocketToServiceRecord(UUID_BT);
+            setMensagem("Conectando em " + nomeDoServidor);
+            socket = servidor.createRfcommSocketToServiceRecord(UUID_BT);
             sleep(1000);
 			LOGGER.log(Level.INFO, "Conectando");
             socket.connect();
 			LOGGER.log(Level.INFO, "Conectado");
             setMensagem("Conectado!");
-
-            threadConexao = new Thread(ClienteBluetoothActivity.this);
-            threadConexao.start();
-
+			return true;
         } catch (Exception e) {
             LOGGER.log(Level.INFO,
-                    "Falhou conexao com device " + device.getName(), e);
-            msgErroFatal("Falhou conexao com device " + device.getName() + ". Veja se o seu aparelho está pareado/autorizado com o que criou o jogo e tente novamente.");
+                    "Falhou conexao com " + nomeDoServidor, e);
+            msgErroFatal("Não foi possível conectar com " + nomeDoServidor + ". Veja se o o seu aparelho está pareado/autorizado com ele e tente novamente.");
             try {
                 socket.close();
             } catch (Exception e1) {
                 // Sem problemas, era só pra garantir
             }
+			return false;
         }
     }
 
@@ -349,8 +348,9 @@ public class ClienteBluetoothActivity extends BluetoothBaseActivity implements
                 .setItems(criaArrayComNomeDosAparelhosPareados(), new AlertDialog.OnClickListener() {
 
                     public void onClick(DialogInterface dialog, int posicaoNaLista) {
-
-                        conectaNoServidor(dispositivosPareados.get(posicaoNaLista));
+                        servidor = dispositivosPareados.get(posicaoNaLista);
+						threadConexao = new Thread(ClienteBluetoothActivity.this);
+			            threadConexao.start();
                     }
                 }).show();
     }

--- a/app/src/main/java/me/chester/minitruco/android/bluetooth/ClienteBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/bluetooth/ClienteBluetoothActivity.java
@@ -282,10 +282,14 @@ public class ClienteBluetoothActivity extends BluetoothBaseActivity implements
      */
     private void conectaNoServidor(BluetoothDevice device) {
         try {
+			LOGGER.log(Level.INFO, "Criando socket");
+			LOGGER.log(Level.INFO, "device.getName()");
             setMensagem("Consultando " + device.getName());
             socket = device.createRfcommSocketToServiceRecord(UUID_BT);
             sleep(1000);
+			LOGGER.log(Level.INFO, "Conectando");
             socket.connect();
+			LOGGER.log(Level.INFO, "Conectado");
             setMensagem("Conectado!");
 
             threadConexao = new Thread(ClienteBluetoothActivity.this);

--- a/app/src/main/java/me/chester/minitruco/android/bluetooth/ClienteBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/bluetooth/ClienteBluetoothActivity.java
@@ -42,21 +42,32 @@ public class ClienteBluetoothActivity extends BluetoothBaseActivity implements
 	private int posJogador;
 
 	@Override
+	Logger logger() {
+		return LOGGER;
+	}
+
+	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		currentInstance = this;
 	}
 
 	@Override
+	void iniciaAtividadeBluetooth() {
+		listaDispositivosPareados();
+	}
+
+	@Override
 	protected void onPostCreate(Bundle savedInstanceState) {
 		super.onPostCreate(savedInstanceState);
-		listaDispositivosPareados();
 	}
 
 	@Override
 	protected void onDestroy() {
 		super.onDestroy();
-		dispositivosPareados.clear();
+		if (dispositivosPareados != null) {
+			dispositivosPareados.clear();
+		}
 		finalizaThreadFechandoConexoes();
 	}
 

--- a/app/src/main/java/me/chester/minitruco/android/bluetooth/ClienteBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/bluetooth/ClienteBluetoothActivity.java
@@ -341,7 +341,7 @@ public class ClienteBluetoothActivity extends BluetoothBaseActivity implements
             return;
         }
 
-        new AlertDialog.Builder(this).setTitle("Escolha o Servidor")
+        new AlertDialog.Builder(this).setTitle("Escolha o celular que criou o jogo")
                 .setItems(criaArrayComNomeDosAparelhosPareados(), new AlertDialog.OnClickListener() {
 
                     public void onClick(DialogInterface dialog, int posicaoNaLista) {

--- a/app/src/main/res/layout/truco.xml
+++ b/app/src/main/res/layout/truco.xml
@@ -15,23 +15,24 @@
 
         <TextView
             android:id="@+id/textview_eles"
-            android:layout_width="wrap_content"
+            android:layout_width="80sp"
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_alignParentRight="true"
             android:layout_marginRight="4dp"
-            android:text="Eles: 0"
+            android:text=""
             android:textColor="#000000"
             android:textSize="20dp"
             android:typeface="sans" />
 
         <TextView
+            android:gravity="right"
             android:id="@+id/textview_nos"
-            android:layout_width="wrap_content"
+            android:layout_width="80sp"
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_marginLeft="4dp"
-            android:text="Nós: 0"
+            android:text=""
             android:textColor="#000000"
             android:textSize="20dp"
             android:typeface="sans" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,10 +156,11 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
+            - Confirmação ao sair do jogo com botão Voltar</br>
             - Ajustes visuais para celulares com borda redonda<br/>
-            - Padronização do esquema de cores<br/>
-            - Correções e melhor comunicação nas permissões de conexão Bluetooth<br/>
             - Impedido acionamento duplo do botão de truco<br/>
+            - Correções e melhor comunicação nas permissões de conexão Bluetooth<br/>
+            - Padronização do esquema de cores (possível correção para modo escuro nos Poco X3 Pro)<br/>
         ]]>
     </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,8 +156,9 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
-            - Melhorias visuais em versões específicas do Android<br/>
-            - Gerenciamento de permissões do Bluetooth melhorado<br/>
+            - Ajustes visuais para celulares com borda redonda<br/>
+            - Padronização do esquema de cores<br/>
+            - Correções e melhor comunicação nas permissões e conexão Bluetooth<br/>
         ]]>
     </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
             - Confirmação ao sair do jogo com botão Voltar</br>
             - Ajustes visuais para celulares com borda redonda<br/>
             - Impedido acionamento duplo do botão de truco<br/>
+            - Quando o botão voltar é usado na tela de título, fecha o jogo (em Android 5 ou superior)<br/>
             - Correções e melhor comunicação nas permissões de conexão Bluetooth<br/>
             - Padronização do esquema de cores (possível correção para modo escuro nos Poco X3 Pro)<br/>
         ]]>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,7 +156,7 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
-            - Confirmação ao sair do jogo com botão Voltar</br>
+            - Confirmação ao sair do jogo com botão Voltar<br/>
             - Ajustes visuais para celulares com borda redonda<br/>
             - Impedido acionamento duplo do botão de truco<br/>
             - Quando o botão voltar é usado na tela de título, fecha o jogo (em Android 5 ou superior)<br/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,8 +156,8 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
-            - Correção final do congelamento (🤞 - ficou 12h jogando sozinho sem congelar)<br/>
-            - Opção de deixar o celular jogar sozinho (para ajudar desenvolvedor com problemas como este)
+            - Melhorias visuais em versões específicas do Android<br/>
+            - Gerenciamento de permissões do Bluetooth melhorado<br/>
         ]]>
     </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,7 +158,8 @@
         <![CDATA[
             - Ajustes visuais para celulares com borda redonda<br/>
             - Padronização do esquema de cores<br/>
-            - Correções e melhor comunicação nas permissões e conexão Bluetooth<br/>
+            - Correções e melhor comunicação nas permissões de conexão Bluetooth<br/>
+            - Impedido acionamento duplo do botão de truco<br/>
         ]]>
     </string>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="miniTrucoTheme" parent="@android:style/Theme.Holo">
+
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
O multiplayer exigia fixar o tema, então dei uma pausa no multiplayer para resolver os problemas mais sérios e alguns dos mais fáceis:

- Refeita a parte de permissões Bluetooth, considerando as diferentes versões de Android (são 3 faixas: num ponto de corte, as permissões mudaram de genéricas para específicas, noutro, passaram a ser obrigatórias), mensagens mais informativas, menos código de conexão na thread principal e tratamento apropriado da resposta negativa.
- Fechando app quando botão voltar sai da tela de título (closes #28)
- Confirmando quando botão voltar encerra o jogo (closes #20)
- Fixa o tema (Theme.Holo); talvez isso resolva o problema do dark mode (#45), mas já garante cores melhores para os botões e uma navegação mais visível (parte de #21)
- Muda o placar para não grudar na porta (closes #27)
- Esconde o botão de truco imediatamente - talvez* resolva #29, é difícil reproduzir
- Sobe versão mínima de API 14 (Android 4) para 16 (Android 4.1), liberando mais features do Java 8 e AppCompat
- Atualiza o plugin do Gradle e simplifica/remanuseia dependências no arquivo de build (agora é possível gerenciar no Android Studio diretamente)

Testada no motorola XT1069 (Android 6) e Pixel 2 (Android 11), e em emulador com Android 4.1, 5, 10 e 13 (Emulador só simula Bluetooth no 13, então é 🤞 )