### PR TITLE
Evita exceção quando o bitmap da carta é reciclado entre a recuperação dele e a exibição

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/CartaVisual.java
+++ b/app/src/main/java/me/chester/minitruco/android/CartaVisual.java
@@ -143,7 +143,8 @@ public class CartaVisual extends Carta {
 				movePara(destLeft, destTop);
 			}
 		}
-		if (getBitmap() != null) {
+		Bitmap bitmapCarta = getBitmap();
+		if (bitmapCarta != null) {
 			int raio_canto = calculaRaioCanto();
 			Paint paint = new Paint();
 			paint.setAntiAlias(true);
@@ -155,7 +156,7 @@ public class CartaVisual extends Carta {
 			canvas.drawRoundRect(rectf, raio_canto, raio_canto, paint);
 			paint.setColor(COR_MESA);
 			paint.setStyle(Paint.Style.FILL);
-			canvas.drawBitmap(getBitmap(), left, top, paint);
+			canvas.drawBitmap(bitmapCarta, left, top, paint);
 			paint.setColor(Color.BLACK);
 			paint.setStyle(Paint.Style.STROKE);
 			paint.setStrokeWidth(1);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,12 +156,7 @@
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[
-            - Confirmação ao sair do jogo com botão Voltar<br/>
-            - Ajustes visuais para celulares com borda redonda<br/>
-            - Impedido acionamento duplo do botão de truco<br/>
-            - Quando o botão voltar é usado na tela de título, fecha o jogo (em Android 5 ou superior)<br/>
-            - Correções e melhor comunicação nas permissões de conexão Bluetooth<br/>
-            - Padronização do esquema de cores (possível correção para modo escuro nos Poco X3 Pro)<br/>
+            - Corrige bug que fechava com erro quando o celular estava com pouca memória
         ]]>
     </string>
 


### PR DESCRIPTION
O cache do método não parece estar funcionando tão bem quanto eu esperava (provavelmente porque a segunda chamada vê que ele foi reciclado); guardo o bitmap numa variável para evitar a segunda chamada.

…

Exceção:

Exception java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.graphics.Bitmap.isRecycled()' on a null object reference
  at android.graphics.BaseCanvas.throwIfCannotDraw (BaseCanvas.java:69)
  at android.view.DisplayListCanvas.throwIfCannotDraw (DisplayListCanvas.java:226)
  at android.view.RecordingCanvas.drawBitmap (RecordingCanvas.java:82)
  at me.chester.minitruco.android.CartaVisual.draw (CartaVisual.java:158)
  at me.chester.minitruco.android.MesaView.onDraw (MesaView.java:669)
  at android.view.View.draw (View.java:21881)
  at android.view.View.updateDisplayListIfDirty (View.java:20754)
  at android.view.ViewGroup.recreateChildDisplayList (ViewGroup.java:4542)
  at android.view.ViewGroup.dispatchGetDisplayList (ViewGroup.java:4514)
  at android.view.View.updateDisplayListIfDirty (View.java:20709)
  at android.view.ViewGroup.recreateChildDisplayList (ViewGroup.java:4542)
  at android.view.ViewGroup.dispatchGetDisplayList (ViewGroup.java:4514)
  at android.view.View.updateDisplayListIfDirty (View.java:20709)
  at android.view.ViewGroup.recreateChildDisplayList (ViewGroup.java:4542)
  at android.view.ViewGroup.dispatchGetDisplayList (ViewGroup.java:4514)
  at android.view.View.updateDisplayListIfDirty (View.java:20709)
  at android.view.ViewGroup.recreateChildDisplayList (ViewGroup.java:4542)
  at android.view.ViewGroup.dispatchGetDisplayList (ViewGroup.java:4514)
  at android.view.View.updateDisplayListIfDirty (View.java:20709)
  at android.view.ThreadedRenderer.updateViewTreeDisplayList (ThreadedRenderer.java:725)
  at android.view.ThreadedRenderer.updateRootDisplayList (ThreadedRenderer.java:731)
  at android.view.ThreadedRenderer.draw (ThreadedRenderer.java:840)
  at android.view.ViewRootImpl.draw (ViewRootImpl.java:3944)
  at android.view.ViewRootImpl.performDraw (ViewRootImpl.java:3718)
  at android.view.ViewRootImpl.performTraversals (ViewRootImpl.java:3026)
  at android.view.ViewRootImpl.doTraversal (ViewRootImpl.java:1885)
  at android.view.ViewRootImpl$TraversalRunnable.run (ViewRootImpl.java:8508)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:949)
  at android.view.Choreographer.doCallbacks (Choreographer.java:761)
  at android.view.Choreographer.doFrame (Choreographer.java:696)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:935)
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7050)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:494)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:965)