### PR TITLE
Remove permissão de internet e bump pra 2.4.1

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,10 @@
         android:anyDensity="true"
         android:largeScreens="true"
         android:normalScreens="true"
-        android:smallScreens="true" /> <!-- Jogo via Bluetooth -->
+        android:smallScreens="true" />
+    <!--
+        Jogo via Bluetooth
+    -->
     <uses-permission
         android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />
@@ -22,9 +25,16 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission
         android:name="android.permission.BLUETOOTH_SCAN"
-        android:usesPermissionFlags="neverForLocation" /> <!-- Jogo via internet -->
+        android:usesPermissionFlags="neverForLocation" />
+    <!--
+        Jogo via internet
+    -->
+    <!--
+        Vamos deixar comentado enquanto não lançamos isso, para evitar
+        pedir uma permissão sem necessidade.
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    -->
 
     <uses-feature
         android:name="android.hardware.touchscreen"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="me.chester.minitruco"
-    android:versionCode="20400"
-    android:versionName="2.4.0">
+    android:versionCode="20401"
+    android:versionName="2.4.1">
     <!--
          Ao aumentar a versão, atualize também o versionCode
          e não esqueça do "novidades" em strings.xml"


### PR DESCRIPTION
Essa permissão só faz sentido quando tivermos o jogo via internet; eu peguei o alerta na hora de publicar e atualizei.

(eu tinha esquecido de dar push nisso quando comecei #73 🙈)