### PR TITLE
Seletor de cor de fundo para carta (e migração pra AppCompat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ Pull requests são bem-vindas, mas não há garantia de aceite (em particular de
 Créditos
 --------
 
-TODO: adicionar licença e (c), para confirmidade com Apache License -> https://github.com/jaredrummler/ColorPicker
-
 - Idéia, desenvolvimento, manutenção e arte: **[Carlos Duarte do Nascimento](https://chester.me)** ([@chesterbr](https://github.com/chesterbr))
 - Imagens de carta, fundo e logotipo: **[Vanessa Sabino](https://baniverso.com)** ([@bani](https://github.com/bani))
 - Tento mineiro: **[Guilherme Caram](https://www.linkedin.com/in/guilherme-caram-meireles/)** ([@gcaram](https://github.com/gcaram))
@@ -37,3 +35,5 @@ TODO: adicionar licença e (c), para confirmidade com Apache License -> https://
   - **[Sandro Gasparoto](https://www.linkedin.com/in/sgasparoto/)**
 - Estratégia de bot antiga: **[Willian Gigliotti](https://www.linkedin.com/in/willian-gigliotti/)**
 - Seleção manual de servidor Bluetooth: **[Rodolfo Vasconcelos](https://www.linkedin.com/in/rodolfo-de-andrade-vasconcelos/)**
+- [Color Picker](https://github.com/jaredrummler/ColorPicker) © 2016 Jared Rummler / © 2015 Daniel Nilsson
+  Licensed under the [Apache License, Version 2.0](https://github.com/jaredrummler/ColorPicker/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Pull requests são bem-vindas, mas não há garantia de aceite (em particular de
 Créditos
 --------
 
+TODO: adicionar licença e (c), para confirmidade com Apache License -> https://github.com/jaredrummler/ColorPicker
+
 - Idéia, desenvolvimento, manutenção e arte: **[Carlos Duarte do Nascimento](https://chester.me)** ([@chesterbr](https://github.com/chesterbr))
 - Imagens de carta, fundo e logotipo: **[Vanessa Sabino](https://baniverso.com)** ([@bani](https://github.com/bani))
 - Tento mineiro: **[Guilherme Caram](https://www.linkedin.com/in/guilherme-caram-meireles/)** ([@gcaram](https://github.com/gcaram))

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,4 +23,5 @@ dependencies {
 
     implementation project(path: ':core')
     implementation 'androidx.preference:preference:1.2.0'
+    implementation 'com.jaredrummler:colorpicker:1.1.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,4 +22,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
 
     implementation project(path: ':core')
+    implementation 'androidx.preference:preference:1.2.0'
 }

--- a/app/src/main/java/me/chester/minitruco/android/BaseActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/BaseActivity.java
@@ -8,7 +8,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 
-import androidx.activity.ComponentActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
 
 import me.chester.minitruco.R;
@@ -20,7 +20,7 @@ import me.chester.minitruco.R;
  * Processa menus e diálogos comuns à tela de título (
  * <code>TituloActivity</code>) e à tela de jogo (<code>TrucoActivity</code>).
  */
-public abstract class BaseActivity extends ComponentActivity {
+public abstract class BaseActivity extends AppCompatActivity {
 
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);

--- a/app/src/main/java/me/chester/minitruco/android/BaseActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/BaseActivity.java
@@ -3,13 +3,13 @@ package me.chester.minitruco.android;
 import android.app.AlertDialog;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager.NameNotFoundException;
-import android.preference.PreferenceManager;
 import android.text.Html;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 
 import androidx.activity.ComponentActivity;
+import androidx.preference.PreferenceManager;
 
 import me.chester.minitruco.R;
 

--- a/app/src/main/java/me/chester/minitruco/android/CartaVisual.java
+++ b/app/src/main/java/me/chester/minitruco/android/CartaVisual.java
@@ -32,6 +32,7 @@ public class CartaVisual extends Carta {
     private final static Logger LOGGER = Logger.getLogger("CartaVisual");
 
     public static final int COR_MESA = Color.argb(255, 27, 142, 60);
+    private int corFundo;
 
     /**
      * Cria uma nova carta na posição indicada
@@ -42,10 +43,13 @@ public class CartaVisual extends Carta {
      *            posição em relação ao topo
      * @param sCarta
      *            valor que esta carta terá (ex.: "Kc"). Se null, entra virada.
+     * @param corFundo
+     *            cor de fundo da carta
      */
-    public CartaVisual(MesaView mesa, int left, int top, String sCarta) {
+    public CartaVisual(MesaView mesa, int left, int top, String sCarta, int corFundo) {
         super(sCarta == null ? LETRA_NENHUMA + "" + NAIPE_NENHUM : sCarta);
         this.mesa = mesa;
+        this.corFundo = corFundo;
         movePara(left, top);
     }
 
@@ -148,7 +152,7 @@ public class CartaVisual extends Carta {
             Rect rect = new Rect(left, top, left + largura - 1, top + altura
                     - 1);
             RectF rectf = new RectF(rect);
-            paint.setColor(Color.WHITE);
+            paint.setColor(corFundo);
             paint.setStyle(Paint.Style.FILL);
             canvas.drawRoundRect(rectf, raio_canto, raio_canto, paint);
             paint.setColor(COR_MESA);

--- a/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
+++ b/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
@@ -3,7 +3,8 @@ package me.chester.minitruco.android;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.os.Message;
-import android.preference.PreferenceManager;
+
+import androidx.preference.PreferenceManager;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/app/src/main/java/me/chester/minitruco/android/MesaView.java
+++ b/app/src/main/java/me/chester/minitruco/android/MesaView.java
@@ -46,6 +46,7 @@ public class MesaView extends View {
     private final float density = getResources().getDisplayMetrics().density;
 
     private static final Random rand = new Random();
+    private int corFundoCarta;
 
     public MesaView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
@@ -112,7 +113,7 @@ public class MesaView extends View {
         // Na primeira chamada (inicialização), instanciamos as cartas
         if (!inicializada) {
             for (int i = 0; i < cartas.length; i++) {
-                cartas[i] = new CartaVisual(this, leftBaralho, topBaralho, null);
+                cartas[i] = new CartaVisual(this, leftBaralho, topBaralho, null, corFundoCarta);
                 cartas[i].movePara(leftBaralho, topBaralho);
             }
             cartas[0].visible = false;
@@ -1032,5 +1033,9 @@ public class MesaView extends View {
 
     public void setValorMao(int m) {
         valorMao = m;
+    }
+
+    public void setCorFundoCarta(int corFundoCarta) {
+        this.corFundoCarta = corFundoCarta;
     }
 }

--- a/app/src/main/java/me/chester/minitruco/android/OpcoesActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/OpcoesActivity.java
@@ -1,7 +1,9 @@
 package me.chester.minitruco.android;
 
 import android.os.Bundle;
-import android.preference.PreferenceActivity;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 
 import me.chester.minitruco.R;
 
@@ -11,12 +13,10 @@ import me.chester.minitruco.R;
 /**
  * Activity que permite configurar manilhas, baralho e outras opções
  */
-public class OpcoesActivity extends PreferenceActivity {
-
+public class OpcoesActivity extends AppCompatActivity {
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.opcoes);
+        setContentView(R.layout.opcoes);
     }
-
 }

--- a/app/src/main/java/me/chester/minitruco/android/OpcoesFragment.java
+++ b/app/src/main/java/me/chester/minitruco/android/OpcoesFragment.java
@@ -1,0 +1,15 @@
+package me.chester.minitruco.android;
+
+import android.os.Bundle;
+
+import androidx.preference.PreferenceFragmentCompat;
+
+import me.chester.minitruco.R;
+
+public class OpcoesFragment extends PreferenceFragmentCompat {
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.opcoes, rootKey);
+    }
+
+}

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -8,12 +8,13 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.os.Build;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
+
+import androidx.preference.PreferenceManager;
 
 import me.chester.minitruco.BuildConfig;
 import me.chester.minitruco.R;

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -1,5 +1,6 @@
 package me.chester.minitruco.android;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
@@ -35,7 +36,7 @@ import me.chester.minitruco.core.JogoLocal;
  * de uma <code>MesaView</code>.
  * <p>
  */
-public class TrucoActivity extends BaseActivity {
+public class TrucoActivity extends Activity {
 
     private MesaView mesa;
     private View layoutFimDeJogo;

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -7,7 +7,6 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
-import android.preference.PreferenceManager;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
@@ -16,6 +15,7 @@ import android.widget.CheckBox;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
 
 import me.chester.minitruco.R;
 import me.chester.minitruco.android.multiplayer.bluetooth.ClienteBluetoothActivity;

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -158,6 +158,7 @@ public class TrucoActivity extends BaseActivity {
         setContentView(R.layout.truco);
         preferences = PreferenceManager.getDefaultSharedPreferences(this);
         mesa = findViewById(R.id.MesaView01);
+        mesa.setCorFundoCarta(preferences.getInt("corFundoCarta", Color.WHITE));
         layoutFimDeJogo = findViewById(R.id.layoutFimDeJogo);
 
         mesa.velocidade = Integer.parseInt(preferences.getString("velocidadeAnimacao", "1"));

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -10,11 +10,12 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+
+import androidx.preference.PreferenceManager;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -9,10 +9,11 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.widget.EditText;
 import android.widget.TextView;
+
+import androidx.preference.PreferenceManager;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;

--- a/app/src/main/res/layout/fragment_opcoes.xml
+++ b/app/src/main/res/layout/fragment_opcoes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".android.OpcoesFragment">
+</FrameLayout>

--- a/app/src/main/res/layout/opcoes.xml
+++ b/app/src/main/res/layout/opcoes.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragmentContainerView"
+        android:name="me.chester.minitruco.android.OpcoesFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,24 +201,24 @@
         ]]>
     </string>
     <string name="titulo_sobre">Sobre o miniTruco</string>
-    <string name="texto_sobre">        <![CDATA[miniTruco-android: Copyright © 2005-2023 Carlos
-        Duarte do Nascimento (Chester) - cd@pobox.com
+    <string name="texto_sobre"><![CDATA[
+        miniTruco-android: Copyright © 2005-2023 Carlos Duarte do Nascimento (Chester) - cd@pobox.com
         <br/><br/>Seleção manual de servidor Bluetooth: Copyright © 2016 Rodolfo Vasconcelos
         <br/><br/>Tento mineiro: Copyright © 2011 Guilherme Caram
         <br/><br/>Imagens de carta, fundo e logotipo: Copyright © 2010-2011 Vanessa Sabino (Bani)
-        <br/><br/>Estratégias de bots: Copyright © 2006-2011 Leonardo Sellani, Sandro Gasparotto<br/>
-        <br/><br/>Estratégia de bot (antiga): Copyright © 2006-2011 Willian Gigliotti<br/>
-        TODO: adicionar licença e ©, para confirmidade com Apache License -> https://github.com/jaredrummler/ColorPicker
-        <br/>
+        <br/><br/>Estratégias de bots: Copyright © 2006-2011 Leonardo Sellani, Sandro Gasparotto
+        <br/><br/>Estratégia de bot (antiga): Copyright © 2006-2011 Willian Gigliotti
+        <br/><br/>Color Picker © 2016 Jared Rummler / © 2015 Daniel Nilsson - Licensed under the Apache License, Version 2.0 (https://github.com/jaredrummler/ColorPicker/blob/master/LICENSE)
+        <br/><br/>
         Código-fonte: http://github.com/chesterbr/minitruco-android
-        <br/>
+        <br/><br/>
         <br/><br/>Todos os direitos reservados.
         <br/><br/>A redistribuiçã̃o e o uso nas formas binária e código fonte, com ou sem modificações, são permitidos contanto que as condições abaixo sejam cumpridas:
         <br/><br/>- Redistribuições do código fonte devem conter o aviso de direitos autorais acima, esta lista de condições e o aviso de isenção de garantias subsequente.
         <br/><br/>- Redistribuições na forma binária devem reproduzir o aviso de direitos autorais acima, esta lista de condições e o aviso de isenção de garantias subsequente na documentação e/ou materiais fornecidos com a distribuição.
         <br/><br/>- Nem o nome do Chester nem o nome dos contribuidores podem ser utilizados para endossar ou promover produtos derivados deste software sem autorização prévia específica por escrito.
-        <br/><br/>]]>
-    </string>
+        <br/><br/>
+    ]]></string>
     <string name="jogar_bold"><b>Jogar</b></string>
     <string name="novidades">
         <![CDATA[

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,6 +208,7 @@
         <br/><br/>Imagens de carta, fundo e logotipo: Copyright © 2010-2011 Vanessa Sabino (Bani)
         <br/><br/>Estratégias de bots: Copyright © 2006-2011 Leonardo Sellani, Sandro Gasparotto<br/>
         <br/><br/>Estratégia de bot (antiga): Copyright © 2006-2011 Willian Gigliotti<br/>
+        TODO: adicionar licença e ©, para confirmidade com Apache License -> https://github.com/jaredrummler/ColorPicker
         <br/>
         Código-fonte: http://github.com/chesterbr/minitruco-android
         <br/>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="miniTrucoTheme" parent="@android:style/Theme.Holo">
-
+    <style name="miniTrucoTheme" parent="@style/Theme.AppCompat">
+        <item name="colorButtonNormal">#FF1D3929</item>
+        <item name="android:textAllCaps">false</item>
     </style>
 </resources>

--- a/app/src/main/res/xml/opcoes.xml
+++ b/app/src/main/res/xml/opcoes.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<androidx.preference.PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <CheckBoxPreference
         android:defaultValue="true"
         android:key="sempreConfirmaFecharJogo"
@@ -27,4 +28,4 @@
             android:summary="Joga uma carta ou pede truco automaticamente (e aleatoriamente) apenas em jogo local."
             android:title="Jogo Automático" />
     </PreferenceCategory>
-</PreferenceScreen>
+</androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/opcoes.xml
+++ b/app/src/main/res/xml/opcoes.xml
@@ -17,6 +17,10 @@
         android:entryValues="@array/velocidade_animacao_valores"
         android:key="velocidadeAnimacao"
         android:title="Velocidade da Animação" />
+    <com.jaredrummler.android.colorpicker.ColorPreferenceCompat
+        android:defaultValue="-1"
+        android:key="corFundoCarta"
+        android:title="Cor de fundo das cartas"/>
     <PreferenceCategory android:title="Opções de Desenvolvimento (sério, nem mexe aqui)">
         <EditTextPreference
             android:defaultValue="@string/opcoes_default_servidor"


### PR DESCRIPTION
Coloca um picker de cor que deve ajudar quem tem Xiaomi Poco F1 e o dark mode inventa de escurecer as cartas (e outros celulares que também façam isso), e também quem, por algum motivo, quiser botar outra cor nas cartas.

Color Picker usado: https://github.com/jaredrummler/ColorPicker

Em tese esse picker funciona sem precisar de AppCompat, mas como eu experimentei vários (e alguns precisavam), acabei mudando o tema (ajustando a cor e case dos botões) e migrando as Preferences todas, o que mata uns warnings. Os diálogos agora ficam naquele estilo ~horroroso~ moderno do Android, mas parece que o futuro é esse e eu tenho que aceitar 🤷. 

Aproveitei também para tirar a AppBar do jogo (alguém tinha sugerido isso)

Fixes #45 🤞 
Release #88 