### PR TITLE
Indicador da vez na mão de 11 e mesa no editor

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/CartaVisual.java
+++ b/app/src/main/java/me/chester/minitruco/android/CartaVisual.java
@@ -25,6 +25,9 @@ import me.chester.minitruco.core.Carta;
  * <p>
  * Esta classe faz o desenho da carta, executa sua animação, e ajusta sua
  * proporção para a resolução do celular.
+ * <p>
+ * Ela poderia até ser uma custom View, mas na real ela é parte integrante
+ * de MesaView, então vamos com uma classe mais simples.
  */
 public class CartaVisual extends Carta {
 
@@ -47,9 +50,12 @@ public class CartaVisual extends Carta {
      *            valor que esta carta terá (ex.: "Kc"). Se null, entra virada.
      * @param corFundo
      *            cor de fundo da carta
+     * @param resources
+     *            getResources() da mesa (para podermos recuperar bitmaps, etc.)
      */
-    public CartaVisual(MesaView mesa, int left, int top, String sCarta, int corFundo) {
+    public CartaVisual(MesaView mesa, int left, int top, String sCarta, int corFundo, Resources resources) {
         super(sCarta == null ? LETRA_NENHUMA + "" + NAIPE_NENHUM : sCarta);
+        this.resources = resources;
         this.mesa = mesa;
         this.corFundo = corFundo;
         movePara(left, top);
@@ -195,17 +201,14 @@ public class CartaVisual extends Carta {
     }
 
     /**
-     * Associa uma carta do jogo (i.e., não visual) a esse objeto carta visual
+     * Copia a letra, naipe e estado de fechamento de uma carta do jogo
+     * (i.e., não visual)
      *
      * @param c
-     *            carta a ser associada. Se <code>null</code>, desassocia a
-     *            carta visual de qualquer carta real.
+     *            carta a ser copiada. Se <code>null</code>, a carta visual
+     *            vira apenas uma carta "fechada"
      */
-    public void setCarta(Carta c) {
-        if (resources == null) {
-            throw new IllegalStateException(
-                    "CartaVisual tem que ter a propriedade resources inicializada");
-        }
+    public void copiaCarta(Carta c) {
         if (c == null) {
             this.setLetra(LETRA_NENHUMA);
             this.setNaipe(NAIPE_NENHUM);
@@ -366,10 +369,9 @@ public class CartaVisual extends Carta {
     public boolean destacada = false;
 
     /**
-     * Acessor dos resources da aplicação (deve ser setado antes de chamar
-     * onDraw por uma Activity que tenha acesso a getResources())
+     * Acessor dos resources da aplicação
      */
-    public static Resources resources;
+    private Resources resources;
 
     /**
      * Mesa à qual esta carta pertence

--- a/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
+++ b/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
@@ -76,7 +76,7 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
     }
 
     @Override
-    public void inicioMao() {
+    public void inicioMao(Jogador jogadorQueAbre) {
         valorProximaAposta = 3;
         for (int i = 0; i <= 2; i++) {
             mesa.resultadoRodada[i] = 0;
@@ -84,6 +84,7 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
         LOGGER.log(Level.INFO, "distribuindo a mão");
         mesa.distribuiMao();
         mesa.setValorMao(jogo.getModo().valorInicialDaMao());
+        mesa.setPosicaoVez(posicaoNaTela(jogadorQueAbre));
         activity.handler.sendMessage(Message.obtain(activity.handler,
                 TrucoActivity.MSG_TIRA_DESTAQUE_PLACAR));
     }
@@ -132,6 +133,7 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
         activity.handler.sendMessage(Message.obtain(activity.handler,
                 TrucoActivity.MSG_ATUALIZA_PLACAR, pontosNos, pontosEles));
         mesa.setValorMao(0);
+        mesa.setPosicaoVez(0);
         mesa.recolheMao();
 
     }

--- a/app/src/main/java/me/chester/minitruco/android/MesaView.java
+++ b/app/src/main/java/me/chester/minitruco/android/MesaView.java
@@ -49,8 +49,8 @@ public class MesaView extends View {
     private final float density = getResources().getDisplayMetrics().density;
 
     private static final Random rand = new Random();
-    private int corFundoCarta;
-    private Paint paintIconesRodadas = new Paint();
+    private int corFundoCarta = Color.WHITE;
+    private final Paint paintIconesRodadas = new Paint();
 
     public MesaView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
@@ -118,7 +118,7 @@ public class MesaView extends View {
         // Na primeira chamada (inicialização), instanciamos as cartas
         if (!inicializada) {
             for (int i = 0; i < cartas.length; i++) {
-                cartas[i] = new CartaVisual(this, leftBaralho, topBaralho, null, corFundoCarta);
+                cartas[i] = new CartaVisual(this, leftBaralho, topBaralho, null, corFundoCarta, getResources());
                 cartas[i].movePara(leftBaralho, topBaralho);
             }
             cartas[0].visible = false;
@@ -150,7 +150,6 @@ public class MesaView extends View {
             // a diálogos e faz a activity começar o jogo
             threadAnimacao.start();
             respondeDialogos.start();
-            inicializada = true;
             if (this.trucoActivity != null) {
                 this.trucoActivity.criaEIniciaNovoJogo();
             }
@@ -182,33 +181,39 @@ public class MesaView extends View {
         int lado = CartaVisual.altura / 2;
         iconesRodadas = new Bitmap[23];
         iconesRodadas[0] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.placarrodada0)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.placarrodada0)).getBitmap(), lado, lado, true);
         iconesRodadas[1] =  Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.placarrodada1)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.placarrodada1)).getBitmap(), lado, lado, true);
         iconesRodadas[2] =  Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.placarrodada2)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.placarrodada2)).getBitmap(), lado, lado, true);
         iconesRodadas[3] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.placarrodada3)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.placarrodada3)).getBitmap(), lado, lado, true);
         // indice = valorMao + 10
         iconesRodadas[10] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.placarrodada0)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.placarrodada0)).getBitmap(), lado, lado, true);
         iconesRodadas[11] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.valorrodada1)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.valorrodada1)).getBitmap(), lado, lado, true);
         iconesRodadas[12] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.valorrodada2)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.valorrodada2)).getBitmap(), lado, lado, true);
         iconesRodadas[13] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.valorrodada3)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.valorrodada3)).getBitmap(), lado, lado, true);
         iconesRodadas[14] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.valorrodada4)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.valorrodada4)).getBitmap(), lado, lado, true);
         iconesRodadas[16] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.valorrodada6)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.valorrodada6)).getBitmap(), lado, lado, true);
         iconesRodadas[19] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.valorrodada9)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.valorrodada9)).getBitmap(), lado, lado, true);
         iconesRodadas[20] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.valorrodada10)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.valorrodada10)).getBitmap(), lado, lado, true);
         iconesRodadas[22] = Bitmap.createScaledBitmap(((BitmapDrawable) ContextCompat
-            .getDrawable(trucoActivity, R.drawable.valorrodada12)).getBitmap(), lado, lado, true);
+            .getDrawable(getContext(), R.drawable.valorrodada12)).getBitmap(), lado, lado, true);
 
+        if (!inicializada && isInEditMode()) {
+            velocidade = 4;
+            distribuiMao();
+        }
+
+        inicializada = true;
 }
 
     /**
@@ -263,7 +268,7 @@ public class MesaView extends View {
      */
     public void mostraCartasMaoDeX(Carta[] cartasParceiro) {
         for (int i = 0; i <= 2; i++) {
-            cartas[10 + i].setCarta(cartasParceiro[i]);
+            cartas[10 + i].copiaCarta(cartasParceiro[i]);
         }
     }
 
@@ -510,13 +515,18 @@ public class MesaView extends View {
         // Atribui o valor correto às cartas do jogador e exibe
         for (int i = 0; i <= 2; i++) {
             CartaVisual c = cartas[4 + i];
-            c.setCarta(trucoActivity.jogadorHumano.getCartas()[i]);
+            if (isInEditMode()) {
+                c.setLetra("A23".charAt(i));
+                c.setNaipe(i);
+            } else {
+                c.copiaCarta(trucoActivity.jogadorHumano.getCartas()[i]);
+            }
             c.setFechada(false);
         }
 
         // Abre o vira, se for manilha nova
         if (!trucoActivity.jogo.getModo().isManilhaVelha()) {
-            cartas[0].setCarta(trucoActivity.jogo.cartaDaMesa);
+            cartas[0].copiaCarta(trucoActivity.jogo.cartaDaMesa);
             cartas[0].visible = true;
         }
 
@@ -539,7 +549,7 @@ public class MesaView extends View {
             CartaVisual c = cartas[i];
             if ((c.top != topBaralho) || (c.left != leftBaralho)) {
                 c.movePara(leftBaralho, topBaralho, 50);
-                c.setCarta(null);
+                c.copiaCarta(null);
                 c.descartada = false;
                 c.escura = false;
                 cartasJogadas.remove(c);
@@ -577,7 +587,7 @@ public class MesaView extends View {
         }
 
         // Executa a animação de descarte
-        cv.setCarta(c);
+        cv.copiaCarta(c);
         cv.movePara(leftFinal, topFinal, 200);
         cv.descartada = true;
         cartasJogadas.addElement(cv);
@@ -740,6 +750,10 @@ public class MesaView extends View {
                     bmpIcone = iconesRodadas[resultadoRodada[i - 1]];
                 }
 
+                if (isInEditMode()) {
+                    bmpIcone = iconesRodadas[i == 0 ? 11 : i];
+                }
+
                 if (bmpIcone != null) {
                     canvas.drawBitmap(bmpIcone,
                             MARGEM + (i % 2) * (1 + iconesRodadas[0].getWidth()),
@@ -776,7 +790,7 @@ public class MesaView extends View {
         desenhaBalao(canvas);
         desenhaIndicadorDeVez(canvas);
 
-        if (trucoActivity.jogo.isJogoAutomatico()) {
+        if (trucoActivity != null && trucoActivity.jogo.isJogoAutomatico()) {
             jogaCarta(0);
             jogaCarta(1);
             jogaCarta(2);

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -164,11 +164,6 @@ public class TrucoActivity extends Activity {
 
         mesa.velocidade = preferences.getBoolean("animacaoRapida", false) ? 4 : 1;
         mesa.setTrucoActivity(this);
-        // Inicializa componentes das classes visuais que dependem de métodos
-        // disponíveis exclusivamente na Activity
-        if (CartaVisual.resources == null) {
-            CartaVisual.resources = getResources();
-        }
     }
 
     @Override

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/JogadorDummy.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/JogadorDummy.java
@@ -31,7 +31,7 @@ public class JogadorDummy extends Jogador {
 
     }
 
-    public void inicioMao() {
+    public void inicioMao(Jogador jogadorQueAbre) {
 
     }
 

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/JogoRemoto.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/JogoRemoto.java
@@ -117,16 +117,16 @@ public class JogoRemoto extends Jogo {
                 // Gera as cartas e notifica
                 Carta[] cartas = new Carta[3];
                 for (int i = 0; i <= 2; i++) {
-                    cartas[i] = new Carta(tokens[i]);
+                    cartas[i] = new Carta(tokens[i + 1]);
                     baralho.tiraDoBaralho(cartas[i]);
                 }
                 if (!modo.isManilhaVelha()) {
-                    cartaDaMesa = new Carta(tokens[3]);
+                    cartaDaMesa = new Carta(tokens[4]);
                     baralho.tiraDoBaralho(cartaDaMesa);
                 }
                 setManilha(cartaDaMesa);
                 getJogadorHumano().setCartas(cartas);
-                getJogadorHumano().inicioMao();
+                getJogadorHumano().inicioMao(getJogador(Integer.parseInt(tokens[0])));
                 break;
             case 'J':
                 // Recupera o jogador que jogou a carta

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/JogadorBluetooth.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/JogadorBluetooth.java
@@ -143,8 +143,9 @@ public class JogadorBluetooth extends Jogador implements Runnable {
         enviaMensagem("J " + j.getPosicao() + param);
     }
 
-    public void inicioMao() {
+    public void inicioMao(Jogador jogadorQueAbre) {
         StringBuffer comando = new StringBuffer("M");
+        comando.append(" ").append(jogadorQueAbre.getPosicao());
         for (int i = 0; i <= 2; i++)
             comando.append(" ").append(getCartas()[i]);
         // Se for manilha nova, também envia o "vira"

--- a/app/src/main/res/layout/truco.xml
+++ b/app/src/main/res/layout/truco.xml
@@ -20,7 +20,7 @@
             android:layout_alignParentBottom="true"
             android:layout_alignParentRight="true"
             android:layout_marginRight="4dp"
-            android:text=""
+            android:text="👇 9"
             android:textColor="#000000"
             android:textSize="20sp"
             android:typeface="sans" />
@@ -32,7 +32,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_marginLeft="4dp"
-            android:text=""
+            android:text="9 👇"
             android:textColor="#000000"
             android:textSize="20sp"
             android:typeface="sans" />

--- a/core/src/main/java/me/chester/minitruco/core/Jogador.java
+++ b/core/src/main/java/me/chester/minitruco/core/Jogador.java
@@ -116,7 +116,7 @@ public abstract class Jogador {
      * Ao receber esta mensagem, as cartas do jogador já foram atribuídas via
      * setCartas(), e a carta virada já está disponível via getCarta().
      */
-    public abstract void inicioMao();
+    public abstract void inicioMao(Jogador jogadorQueAbre);
 
     /**
      * Informa que uma partida começou. Não é obrigatório tratar - até porque o

--- a/core/src/main/java/me/chester/minitruco/core/JogadorBot.java
+++ b/core/src/main/java/me/chester/minitruco/core/JogadorBot.java
@@ -317,7 +317,7 @@ public class JogadorBot extends Jogador implements Runnable {
         // Não faz nada
     }
 
-    public void inicioMao() {
+    public void inicioMao(Jogador jogadorQueAbre) {
 
         // Guarda as cartas que estão na mão do jogador
         cartasRestantes.removeAllElements();

--- a/core/src/main/java/me/chester/minitruco/core/JogoLocal.java
+++ b/core/src/main/java/me/chester/minitruco/core/JogoLocal.java
@@ -182,7 +182,7 @@ public class JogoLocal extends Jogo {
         // Abre a primeira rodada, informando a carta da mesa e quem vai abrir
         posJogadorDaVez = jogadorQueAbre.getPosicao();
         for (int i = 3; i >= 0; i--) {
-            jogadores[i].inicioMao();
+            jogadores[i].inicioMao(jogadorQueAbre);
         }
 
         int rndFrase = Math.abs(rand.nextInt());

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -196,8 +196,9 @@ public class JogadorConectado extends Jogador implements Runnable {
     }
 
     @Override
-    public void inicioMao() {
+    public void inicioMao(Jogador jogadorQueAbre) {
         StringBuilder comando = new StringBuilder("M");
+        comando.append(" ").append(jogadorQueAbre.getPosicao());
         for (int i = 0; i <= 2; i++)
             comando.append(" ").append(getCartas()[i]);
         if (!jogo.getModo().isManilhaVelha()) {


### PR DESCRIPTION
Inclui o jogador da vez na notificação de beneficiário de mão de 11, garantindo que as pessoas que estiverem em mão de 11 vão ter a informação para decidir se aceitam ou não.

Aproveita para garantir que a mesa seja exibida no editor de layouts do Android Studio

Closes #39 