### PR TITLE
Remove `Handler` de `TrucoActivity`

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
+++ b/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
@@ -2,7 +2,6 @@ package me.chester.minitruco.android;
 
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
-import android.os.Message;
 
 import androidx.preference.PreferenceManager;
 
@@ -81,8 +80,7 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
         mesa.distribuiMao();
         activity.setValorMao(partida.getModo().valorInicialDaMao());
         mesa.setPosicaoVez(posicaoNaTela(jogadorQueAbre));
-        activity.handler.sendMessage(Message.obtain(activity.handler,
-                TrucoActivity.MSG_TIRA_DESTAQUE_PLACAR));
+        activity.tiraDestaqueDoPlacar();
     }
 
     @Override

--- a/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
+++ b/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
@@ -90,9 +90,7 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
         incrementaEstatistica("statPartidas");
         activity.placar[0] = placarEquipe1;
         activity.placar[1] = placarEquipe2;
-        activity.handler.sendMessage(Message
-                .obtain(activity.handler, TrucoActivity.MSG_ATUALIZA_PLACAR,
-                        placarEquipe1, placarEquipe2));
+        activity.atualizaPlacar(placarEquipe1, placarEquipe2);
     }
 
     @Override
@@ -123,8 +121,7 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
         int pontosEles = pontosEquipe[getEquipeAdversaria() - 1];
         mesa.escondeBotaoAumento();
         mesa.escondeBotaoAbertaFechada();
-        activity.handler.sendMessage(Message.obtain(activity.handler,
-                TrucoActivity.MSG_ATUALIZA_PLACAR, pontosNos, pontosEles));
+        activity.atualizaPlacar(pontosNos, pontosEles);
         activity.setValorMao(0);
         mesa.setPosicaoVez(0);
         mesa.recolheMao();

--- a/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
+++ b/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
@@ -116,14 +116,13 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
     @Override
     public void maoFechada(int[] pontosEquipe) {
         int pontosNos = pontosEquipe[getEquipe() - 1];
-        int pontosEles = pontosEquipe[getEquipeAdversaria() - 1];
+        int pontosRivais = pontosEquipe[getEquipeAdversaria() - 1];
+        activity.atualizaPlacar(pontosNos, pontosRivais);
+        activity.setValorMao(0);
         mesa.escondeBotaoAumento();
         mesa.escondeBotaoAbertaFechada();
-        activity.atualizaPlacar(pontosNos, pontosEles);
-        activity.setValorMao(0);
         mesa.setPosicaoVez(0);
         mesa.recolheMao();
-
     }
 
     @Override

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -47,7 +47,6 @@ import me.chester.minitruco.core.PartidaLocal;
  */
 public class TrucoActivity extends Activity {
 
-    static final int MSG_TIRA_DESTAQUE_PLACAR = 1;
     static final int MSG_OFERECE_NOVA_PARTIDA = 2;
     static final int MSG_REMOVE_NOVA_PARTIDA = 3;
     public static final String SEPARADOR_PLACAR_PARTIDAS = " x ";
@@ -65,10 +64,6 @@ public class TrucoActivity extends Activity {
     final Handler handler = new Handler() {
         public void handleMessage(Message msg) {
             switch (msg.what) {
-                case MSG_TIRA_DESTAQUE_PLACAR:
-                    textViewNos.setTextColor(Color.BLACK);
-                    textViewRivais.setTextColor(Color.BLACK);
-                    break;
                 case MSG_OFERECE_NOVA_PARTIDA:
                     if (partida instanceof PartidaLocal) {
                         btnNovaPartida.setVisibility(View.VISIBLE);
@@ -87,8 +82,8 @@ public class TrucoActivity extends Activity {
     };
 
     /**
-     * Atualiza o placar com a nova pontuação. Se houve mudança, pinta o placar
-     * do time que fez a pontuação.
+     * Atualiza o placar com a nova pontuação. Se houve mudança, destaca o
+     * placar do time que pontuou.
      *
      * @param pontosNos pontos da dupla do jogador humano
      * @param pontosRivais pontos da outra dupla
@@ -107,6 +102,17 @@ public class TrucoActivity extends Activity {
             placar[1] = pontosRivais;
         });
     }
+
+    /**
+     * Remove o destaque do placar do time que pontuou (se houver um).
+     */
+    void tiraDestaqueDoPlacar() {
+        runOnUiThread(() -> {
+            textViewNos.setTextColor(Color.BLACK);
+            textViewRivais.setTextColor(Color.BLACK);
+        });
+    }
+
 
     private SharedPreferences preferences;
     private ImageView imageValorMao;

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -48,7 +48,6 @@ import me.chester.minitruco.core.PartidaLocal;
 public class TrucoActivity extends Activity {
 
     static final int MSG_OFERECE_NOVA_PARTIDA = 2;
-    static final int MSG_REMOVE_NOVA_PARTIDA = 3;
     public static final String SEPARADOR_PLACAR_PARTIDAS = " x ";
     private static boolean mIsViva = false;
     final int[] placar = new int[2];
@@ -71,9 +70,6 @@ public class TrucoActivity extends Activity {
                             btnNovaPartida.performClick();
                         }
                     }
-                    break;
-                case MSG_REMOVE_NOVA_PARTIDA:
-                    btnNovaPartida.setVisibility(View.INVISIBLE);
                     break;
                 default:
                     break;
@@ -201,7 +197,7 @@ public class TrucoActivity extends Activity {
     }
 
     public void novaPartidaClickHandler(View v) {
-        Message.obtain(handler, MSG_REMOVE_NOVA_PARTIDA).sendToTarget();
+        btnNovaPartida.setVisibility(View.INVISIBLE);
         criaEIniciaNovoJogo();
     }
 

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -10,8 +10,6 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Message;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
@@ -47,7 +45,6 @@ import me.chester.minitruco.core.PartidaLocal;
  */
 public class TrucoActivity extends Activity {
 
-    static final int MSG_OFERECE_NOVA_PARTIDA = 2;
     public static final String SEPARADOR_PLACAR_PARTIDAS = " x ";
     private static boolean mIsViva = false;
     final int[] placar = new int[2];
@@ -59,23 +56,6 @@ public class TrucoActivity extends Activity {
     TextView textViewNos;
     TextView textViewRivais;
     Button btnNovaPartida;
-
-    final Handler handler = new Handler() {
-        public void handleMessage(Message msg) {
-            switch (msg.what) {
-                case MSG_OFERECE_NOVA_PARTIDA:
-                    if (partida instanceof PartidaLocal) {
-                        btnNovaPartida.setVisibility(View.VISIBLE);
-                        if (partida.isJogoAutomatico()) {
-                            btnNovaPartida.performClick();
-                        }
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-    };
 
     /**
      * Atualiza o placar com a nova pontuação. Se houve mudança, destaca o
@@ -370,8 +350,12 @@ public class TrucoActivity extends Activity {
             } else {
                 textViewPartidas.setText(pontos[0] + SEPARADOR_PLACAR_PARTIDAS + (Integer.parseInt(pontos[1]) + 1));
             }
-            handler.sendMessage(Message.obtain(handler,
-                MSG_OFERECE_NOVA_PARTIDA));
+            if (partida instanceof PartidaLocal) {
+                btnNovaPartida.setVisibility(View.VISIBLE);
+                if (partida.isJogoAutomatico()) {
+                    btnNovaPartida.performClick();
+                }
+            }
         });
     }
 }

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -47,7 +47,6 @@ import me.chester.minitruco.core.PartidaLocal;
  */
 public class TrucoActivity extends Activity {
 
-    static final int MSG_ATUALIZA_PLACAR = 0;
     static final int MSG_TIRA_DESTAQUE_PLACAR = 1;
     static final int MSG_OFERECE_NOVA_PARTIDA = 2;
     static final int MSG_REMOVE_NOVA_PARTIDA = 3;
@@ -59,25 +58,13 @@ public class TrucoActivity extends Activity {
     Partida partida;
     private MesaView mesa;
     private TextView textViewPartidas;
+    TextView textViewNos;
+    TextView textViewRivais;
+    Button btnNovaPartida;
 
     final Handler handler = new Handler() {
         public void handleMessage(Message msg) {
-            TextView textViewNos = findViewById(R.id.textViewNos);
-            TextView textViewRivais = findViewById(R.id.textViewRivais);
-            Button btnNovaPartida = findViewById(R.id.btnNovaPartida);
             switch (msg.what) {
-                case MSG_ATUALIZA_PLACAR:
-                    if (placar[0] != msg.arg1) {
-                        textViewNos.setTextColor(Color.YELLOW);
-                    }
-                    if (placar[1] != msg.arg2) {
-                        textViewRivais.setTextColor(Color.YELLOW);
-                    }
-                    textViewNos.setText((msg.arg1 < 10 ? " " : "") + Integer.toString(msg.arg1));
-                    textViewRivais.setText(Integer.toString(msg.arg2) + (msg.arg2 < 10 ? " " : ""));
-                    placar[0] = msg.arg1;
-                    placar[1] = msg.arg2;
-                    break;
                 case MSG_TIRA_DESTAQUE_PLACAR:
                     textViewNos.setTextColor(Color.BLACK);
                     textViewRivais.setTextColor(Color.BLACK);
@@ -98,6 +85,29 @@ public class TrucoActivity extends Activity {
             }
         }
     };
+
+    /**
+     * Atualiza o placar com a nova pontuação. Se houve mudança, pinta o placar
+     * do time que fez a pontuação.
+     *
+     * @param pontosNos pontos da dupla do jogador humano
+     * @param pontosRivais pontos da outra dupla
+     */
+    void atualizaPlacar(int pontosNos, int pontosRivais) {
+        runOnUiThread(() -> {
+            if (placar[0] != pontosNos) {
+                textViewNos.setTextColor(Color.YELLOW);
+            }
+            if (placar[1] != pontosRivais) {
+                textViewRivais.setTextColor(Color.YELLOW);
+            }
+            textViewNos.setText((pontosNos < 10 ? " " : "") + Integer.toString(pontosNos));
+            textViewRivais.setText(Integer.toString(pontosRivais) + (pontosRivais < 10 ? " " : ""));
+            placar[0] = pontosNos;
+            placar[1] = pontosRivais;
+        });
+    }
+
     private SharedPreferences preferences;
     private ImageView imageValorMao;
     private ImageView[] imagesResultadoRodada;
@@ -148,6 +158,9 @@ public class TrucoActivity extends Activity {
         reorientaLayoutPlacar();
         preferences = PreferenceManager.getDefaultSharedPreferences(this);
         textViewPartidas = findViewById(R.id.textViewPartidas);
+        textViewNos = findViewById(R.id.textViewNos);
+        textViewRivais = findViewById(R.id.textViewRivais);
+        btnNovaPartida = findViewById(R.id.btnNovaPartida);
         imageValorMao = findViewById(R.id.imageValorMao);
         imagesResultadoRodada = new ImageView[3];
         imagesResultadoRodada[0] = findViewById(R.id.imageResultadoRodada1);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,11 +173,6 @@
         aumentos vão a 6, 9 e 12), e não podem ser usados ao mesmo tempo porque algumas das
         manilhas velhas fazem parte do baralho sujo).
         <br/><br/>
-        <b><u>Manilha Fixa</u></b>: Outra opção é jogar apenas com as manilhas sujas, mas mantendo
-        a Além do truco pauilsta e do truco mineiro, um terceiro modo
-        permite jogar com o baralho  \"limpo\" (sem as cartas 4, 5, 6 e 7). As regras são as do
-        truco paulista (porque quase todas as manilhas do mineiro são "sujas").
-        <br/><br/>
         <b><u>Bluetooth</u></b>: Um celular deve criar o jogo, e até três procuram ele. Todos tem
         que estar com a mesma versão do miniTruco, e é necessário parear os celulares antes.
         O modo (paulista, mineiro, baralho limpo, manilha velha) é o que estiver configurando no celular que


### PR DESCRIPTION
Essa classe (que eu usava para garantir que mudanças visuais acontecessem na thread de UI) tinha um warning de leak potencial.

Daria pra contornar mexendo no escopo, mas eu não gosto da abordagem dela de qualquer forma, então troquei todos os eventos ali por métodos simples (colocando um `runOnUiThread` sempre que o método correr o risco de ser chamado por uma thread do jogo).

Closes #105 
Parte de #142 