### PR TITLE
Remove frases que renderizam mal no balão

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
+++ b/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
@@ -198,7 +198,7 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
      *            identificador da estatística (ex.: "statPartidas" para número
      *            de partidas jogadas)
      */
-    private void incrementaEstatistica(String chave) {
+    void incrementaEstatistica(String chave) {
         SharedPreferences preferences = PreferenceManager
                 .getDefaultSharedPreferences(activity);
         int partidas = preferences.getInt(chave, 0);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,10 +87,8 @@
         <item>Toma marreco!</item>
     </string-array>
     <string-array name="balao_derrota">
-        <item>:-(</item>
         <item>Maldição!</item>
         <item>Nem queria ganhar…</item>
-        <item>Ok…</item>
         <item>A próxima é nossa.</item>
         <item>Raios!</item>
     </string-array>

--- a/app/src/test/java/me/chester/minitruco/android/JogadorHumanoTest.java
+++ b/app/src/test/java/me/chester/minitruco/android/JogadorHumanoTest.java
@@ -1,0 +1,46 @@
+package me.chester.minitruco.android;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class JogadorHumanoTest {
+
+    JogadorHumano jogadorHumano;
+    private MesaView mockMesaView;
+
+    @BeforeEach
+    void setUp() {
+        mockMesaView = mock(MesaView.class);
+        jogadorHumano = spy(new JogadorHumano(mock(TrucoActivity.class), mockMesaView));
+    }
+
+    @Test
+    void dizFraseDeVitoriaOuDerrotaNoFimDoJogo() {
+        doNothing().when(jogadorHumano).incrementaEstatistica(any());
+
+        doReturn(1).when(jogadorHumano).getEquipe();
+        jogadorHumano.jogoFechado(1, 0);
+        jogadorHumano.jogoFechado(2, 0);
+
+        doReturn(2).when(jogadorHumano).getEquipe();
+        jogadorHumano.jogoFechado(1, 0);
+        jogadorHumano.jogoFechado(2, 0);
+
+        InOrder inOrder = inOrder(mockMesaView);
+
+        inOrder.verify(mockMesaView).diz(eq("vitoria"), eq(1), anyInt(), eq(0));
+        inOrder.verify(mockMesaView).diz(eq("derrota"), eq(1), anyInt(), eq(0));
+        inOrder.verify(mockMesaView).diz(eq("derrota"), eq(1), anyInt(), eq(0));
+        inOrder.verify(mockMesaView).diz(eq("vitoria"), eq(1), anyInt(), eq(0));
+    }
+}


### PR DESCRIPTION
Ia fazer mudanças maiores como parte de #83 , mas concluí que:

- os únicos dois termos específicos de gênero que restaram  - "ladrão" e "marreco" - são, respectivamente um termo negativo e uma referência a animal sem termo feminino, então não acho que estaria criando um ambiente mais inclusivo mexendo neles
- não vale a pena criar mais confusão no final do jogo com balões extras

então só removi as frases menores que não renderizam bem no balão em alguns tamanhos de tela e deixei o teste que introduzi para fazer a mudança dos balões extras do final do jogo.