### PR TITLE
Consertos gerais de Bluetooth

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -5,6 +5,10 @@ import static android.util.TypedValue.COMPLEX_UNIT_DIP;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -46,6 +50,7 @@ import me.chester.minitruco.core.PartidaLocal;
 public class TrucoActivity extends Activity {
 
     public static final String SEPARADOR_PLACAR_PARTIDAS = " x ";
+    public static final String BROADCAST_IDENTIFIER = "me.chester.minitruco.EVENTO_TRUCO_ACTIVITY";
     private static boolean mIsViva = false;
     final int[] placar = new int[2];
     boolean jogoAbortado = false;
@@ -176,6 +181,20 @@ public class TrucoActivity extends Activity {
         }).start();
     }
 
+    /**
+     * Permite que um cliente bluetooth/internet encerre a atividade ao
+     * detectar uma desconexão.
+     */
+    private BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String evento = intent.getStringExtra("evento");
+            if (evento.equals("desconectado")) {
+                finish();
+            }
+        }
+    };
+
     public void novaPartidaClickHandler(View v) {
         btnNovaPartida.setVisibility(View.INVISIBLE);
         criaEIniciaNovoJogo();
@@ -238,6 +257,7 @@ public class TrucoActivity extends Activity {
     @Override
     protected void onPause() {
         super.onPause();
+        unregisterReceiver(broadcastReceiver);
         mesa.setVisivel(false);
     }
 
@@ -245,6 +265,7 @@ public class TrucoActivity extends Activity {
     protected void onResume() {
         super.onResume();
         mesa.setVisivel(true);
+        registerReceiver(broadcastReceiver, new IntentFilter(BROADCAST_IDENTIFIER));
     }
 
     @Override

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BaseBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BaseBluetoothActivity.java
@@ -32,7 +32,7 @@ import me.chester.minitruco.core.Partida;
  * Tarefas comuns ao cliente e ao servidor Bluetooth: mostrar quem está
  * conectado, garantir que o bt está ligado e as permissões cedidas, etc.
  */
-public abstract class BluetoothBaseActivity extends BaseActivity implements
+public abstract class BaseBluetoothActivity extends BaseActivity implements
         Runnable {
 
     public static String[] BLUETOOTH_PERMISSIONS;
@@ -180,7 +180,7 @@ public abstract class BluetoothBaseActivity extends BaseActivity implements
     protected void msgErroFatal(String mensagem) {
         runOnUiThread(() -> {
             encerraTrucoActivity();
-            BluetoothBaseActivity context = BluetoothBaseActivity.this;
+            BaseBluetoothActivity context = BaseBluetoothActivity.this;
             if (context == null || context.isFinishing()) {
                 return;
             }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothBaseActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothBaseActivity.java
@@ -178,15 +178,22 @@ public abstract class BluetoothBaseActivity extends BaseActivity implements
     }
 
     protected void msgErroFatal(String mensagem) {
-        runOnUiThread(() ->
+        runOnUiThread(() -> {
+            encerraTrucoActivity();
             new AlertDialog.Builder(BluetoothBaseActivity.this)
-                    .setTitle("Erro")
-                    .setMessage(mensagem)
-                    .setOnCancelListener(dialog -> finish())
-                    .setNeutralButton("Ok",
-                            (dialog, which) -> finish())
-                    .show()
-        );
+                .setTitle("Erro")
+                .setMessage(mensagem)
+                .setOnCancelListener(dialog -> finish())
+                .setNeutralButton("Ok",
+                    (dialog, which) -> finish())
+                .show();
+        });
+    }
+
+    private void encerraTrucoActivity() {
+        Intent intent = new Intent(TrucoActivity.BROADCAST_IDENTIFIER);
+        intent.putExtra("evento", "desconectado");
+        sendBroadcast(intent);
     }
 
     protected abstract int getNumClientes();

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothBaseActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothBaseActivity.java
@@ -180,7 +180,11 @@ public abstract class BluetoothBaseActivity extends BaseActivity implements
     protected void msgErroFatal(String mensagem) {
         runOnUiThread(() -> {
             encerraTrucoActivity();
-            new AlertDialog.Builder(BluetoothBaseActivity.this)
+            BluetoothBaseActivity context = BluetoothBaseActivity.this;
+            if (context == null || context.isFinishing()) {
+                return;
+            }
+            new AlertDialog.Builder(context)
                 .setTitle("Erro")
                 .setMessage(mensagem)
                 .setOnCancelListener(dialog -> finish())

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ClienteBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ClienteBluetoothActivity.java
@@ -342,12 +342,15 @@ public class ClienteBluetoothActivity extends BluetoothBaseActivity implements
             return;
         }
 
-        new AlertDialog.Builder(this).setTitle("Escolha o celular que criou o jogo")
-                .setItems(criaArrayComNomeDosAparelhosPareados(), (dialog, posicaoNaLista) -> {
-                    servidor = dispositivosPareados.get(posicaoNaLista);
-                    threadConexao = new Thread(ClienteBluetoothActivity.this);
-                    threadConexao.start();
-                }).show();
+        new AlertDialog.Builder(this)
+            .setTitle("Escolha o celular que criou o jogo")
+            .setItems(criaArrayComNomeDosAparelhosPareados(), (dialog, posicaoNaLista) -> {
+                servidor = dispositivosPareados.get(posicaoNaLista);
+                threadConexao = new Thread(ClienteBluetoothActivity.this);
+                threadConexao.start();
+            })
+            .setOnCancelListener(dialog -> finish())
+            .show();
     }
 
 }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ClienteBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ClienteBluetoothActivity.java
@@ -28,7 +28,7 @@ import me.chester.minitruco.core.Partida;
 /* Copyright © 2005-2023 Carlos Duarte do Nascimento "Chester" <cd@pobox.com> */
 
 @SuppressLint("MissingPermission") // super.onCreate checa as permissões
-public class ClienteBluetoothActivity extends BluetoothBaseActivity implements
+public class ClienteBluetoothActivity extends BaseBluetoothActivity implements
         Runnable, ClienteMultiplayer {
 
     private final static Logger LOGGER = Logger.getLogger("ClienteBluetoothActivity");

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/JogadorBluetooth.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/JogadorBluetooth.java
@@ -58,7 +58,7 @@ public class JogadorBluetooth extends Jogador implements Runnable {
                     break;
                 // Lê o próximo caractre
                 c = in.read();
-                if (c != BluetoothBaseActivity.SEPARADOR_REC) {
+                if (c != BaseBluetoothActivity.SEPARADOR_REC) {
                     // Acumula caracteres até formar uma linha
                     sbLinha.append((char) c);
                 } else {

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.View;
 
 import androidx.preference.PreferenceManager;
@@ -126,6 +127,15 @@ public class ServidorBluetoothActivity extends BaseBluetoothActivity {
             LOGGER.log(Level.INFO, "Activity destruída antes do receiver ser registrado");
         }
         encerraConexoes();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        // Dá um tempinho para os clientes se prepararem antes de permitir
+        // o início de uma nova partida
+        btnIniciar.setEnabled(false);
+        new Handler().postDelayed(() -> atualizaDisplay(), 4000);
     }
 
     public void run() {

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -30,7 +30,7 @@ import me.chester.minitruco.core.PartidaLocal;
 /* Copyright © 2005-2023 Carlos Duarte do Nascimento "Chester" <cd@pobox.com> */
 
 @SuppressLint("MissingPermission")  // super.onCreate checa as permissões
-public class ServidorBluetoothActivity extends BluetoothBaseActivity {
+public class ServidorBluetoothActivity extends BaseBluetoothActivity {
 
     private final static Logger LOGGER = Logger.getLogger("ServidorBluetoothActivity");
 


### PR DESCRIPTION
- Renomeia a classe base para `BaseBluetoothActivity` (alinhando com `ClienteBluetoothActivity` e `ServidorBluetoothActivity`)
- Bloqueia o botão `Jogar` por alguns segundos quando o servidor volta a exibir a sala (dando tempo para os clientes encerrarem suas animacões e se prepararem para um novo jogo) - closes #80
- Fecha a `ClienteBluetoothActivity` quando alguém procura um jogo e dá back ou clica fora da lista (ao invés de deixar tudo verde) - closes #81
- Fecha a `TrucoActivity` (se tiver uma aberta) caso um erro fatal seja exibido (evitando que o jogo fique travado) - closes #152 
- Verifica se a activity bluetooth está finalizada antes de criar o diálogo (talvez feche #119; vamos saber quando for pro ar)