### PR TITLE
Corrige ordem das notificações de desconexão

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/PartidaRemota.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/PartidaRemota.java
@@ -276,8 +276,7 @@ public class PartidaRemota extends Partida {
 
     @Override
     public void abandona(int posicao) {
-        // TODO eu acho que o if aqui é redundante (no geral, só o Jogador 1
-        //.     faria isso mesmo); conferir em outros lugares
+        // O if é necessário porque o caller pode nem saber quem pediu pra abandonar
         if (posicao == 1) {
             cliente.enviaLinha("A");
         }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -318,11 +318,11 @@ public class ServidorBluetoothActivity extends BaseBluetoothActivity {
             apelidos[slot + 1] = APELIDO_BOT;
         }
         status = STATUS_AGUARDANDO;
-        atualizaDisplay();
-        atualizaClientes();
         if (partida != null) {
             partida.abandona(slot + 2);
         }
+        atualizaDisplay();
+        atualizaClientes();
     }
 
     public Partida criaNovaPartida(JogadorHumano jogadorHumano) {


### PR DESCRIPTION
Por algum motivo (e não sei se foi mudança dessa versão, acho que não) quando um socket desconectava no servidor bluetooth, ele estava mandando primeiro a notificação de "info da sala" e depois a de "partida abortada".

O problema é que "info da sala" encerra a partida, fazendo a desconexão ser ignorada. Esse PR resolve isso mandando a notifficação de partida abortada antes de atualizar os clientes com a info da sala.

parte de #158 