### PR TITLE
Não deixa a caixa da pergunta ser arrastada para fora do MesaView

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/MesaView.java
+++ b/app/src/main/java/me/chester/minitruco/android/MesaView.java
@@ -488,6 +488,11 @@ public class MesaView extends View {
             case MotionEvent.ACTION_MOVE:
                 if (ultimoyDaPergunta > -1 && (mostrarPerguntaMaoDeX || mostrarPerguntaAumento)) {
                     int dy = y - ultimoyDaPergunta;
+                    if (rectPergunta.top + dy < 0) {
+                        dy = -rectPergunta.top;
+                    } else if (rectPergunta.bottom + dy > getHeight()) {
+                        dy = getHeight() - rectPergunta.bottom;
+                    }
                     ultimoyDaPergunta = y;
                     rectPergunta.top = rectPergunta.top + dy;
                     rectPergunta.bottom = rectPergunta.bottom + dy;


### PR DESCRIPTION
Isso evita que a pessoa "perca" a caixa.

Vou confessar que eu só escrevi `if (rectPergunta.top)` e o Copilot essencialmente deduziu todo o resto. 😮 