### PR TITLE
Placar de partidas persistente

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
+++ b/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
@@ -107,7 +107,6 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
     @Override
     public void jogoFechado(int numEquipeVencedora, int rndFrase) {
         boolean ganhei = (numEquipeVencedora == this.getEquipe());
-        incrementaEstatistica(ganhei ? "statVitorias" : "statDerrotas");
         mesa.diz(ganhei ? "vitoria" : "derrota", 1, 1000, rndFrase);
         mesa.aguardaFimAnimacoes();
         activity.jogoFechado(numEquipeVencedora);

--- a/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
+++ b/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
@@ -1,10 +1,5 @@
 package me.chester.minitruco.android;
 
-import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
-
-import androidx.preference.PreferenceManager;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -85,7 +80,6 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
 
     @Override
     public void inicioPartida(int placarEquipe1, int placarEquipe2) {
-        incrementaEstatistica("statPartidas");
         activity.placar[0] = placarEquipe1;
         activity.placar[1] = placarEquipe2;
         activity.atualizaPlacar(placarEquipe1, placarEquipe2);
@@ -187,23 +181,6 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
         }
         mesa.vez(j.equals(this));
         mesa.setPosicaoVez(posicaoNaTela(j));
-    }
-
-    /**
-     * Soma um a uma estatística (no. de partidas jogadas, no. de vitórias,
-     * etc.)
-     *
-     * @param chave
-     *            identificador da estatística (ex.: "statPartidas" para número
-     *            de partidas jogadas)
-     */
-    void incrementaEstatistica(String chave) {
-        SharedPreferences preferences = PreferenceManager
-                .getDefaultSharedPreferences(activity);
-        int partidas = preferences.getInt(chave, 0);
-        Editor editor = preferences.edit();
-        editor.putInt(chave, ++partidas);
-        editor.apply();
     }
 
     /**

--- a/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
+++ b/app/src/main/java/me/chester/minitruco/android/JogadorHumano.java
@@ -93,7 +93,7 @@ public class JogadorHumano extends me.chester.minitruco.core.JogadorHumano {
             mesa.aguardaFimAnimacoes();
         }
         if (activity != null) {
-            activity.jogoAbortado = true;
+            activity.partidaAbortada = true;
             activity.finish();
         }
     }

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -60,7 +60,7 @@ public class TituloActivity extends BaseActivity {
             }
             String stats_versao = "Esta é a versão " + versao
                 + " do jogo. Você já iniciou " + partidas
-                + " partidas.<br/><br/>";
+                + " partidas (locais ou multiplayer).<br/><br/>";
             mostraAlertBox(this.getString(R.string.titulo_sobre), stats_versao
                 + this.getString(R.string.texto_sobre));
         });

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -51,8 +51,6 @@ public class TituloActivity extends BaseActivity {
 
         findViewById(R.id.btnSobre).setOnClickListener(v -> {
             int partidas = preferences.getInt("statPartidas", 0);
-            int vitorias = preferences.getInt("statVitorias", 0);
-            int derrotas = preferences.getInt("statDerrotas", 0);
             String versao;
             try {
                 versao = getPackageManager()
@@ -62,8 +60,7 @@ public class TituloActivity extends BaseActivity {
             }
             String stats_versao = "Esta é a versão " + versao
                 + " do jogo. Você já iniciou " + partidas
-                + " partidas, ganhou " + vitorias + " e perdeu " + derrotas
-                + ".<br/><br/>";
+                + " partidas.<br/><br/>";
             mostraAlertBox(this.getString(R.string.titulo_sobre), stats_versao
                 + this.getString(R.string.texto_sobre));
         });

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -50,7 +50,7 @@ public class TrucoActivity extends Activity {
     public static final String BROADCAST_IDENTIFIER = "me.chester.minitruco.EVENTO_TRUCO_ACTIVITY";
     private static boolean mIsViva = false;
     final int[] placar = new int[2];
-    boolean jogoAbortado = false;
+    boolean partidaAbortada = false;
     JogadorHumano jogadorHumano;
     Partida partida;
     private MesaView mesa;
@@ -108,7 +108,7 @@ public class TrucoActivity extends Activity {
      * garantir que a partida só role quando a mesa estiver inicializada) e dali em
      * diante pelo botão de nova partida.
      */
-    private void criaEIniciaNovoJogo() {
+    private void criaEIniciaNovaPartida() {
         preferences.edit().putInt("statPartidas",
             preferences.getInt("statPartidas", 0) + 1
         ).apply();
@@ -116,13 +116,13 @@ public class TrucoActivity extends Activity {
         if (getIntent().hasExtra("multiplayer")) {
             partida = CriadorDePartida.criaNovaPartida(jogadorHumano);
         } else {
-            partida = criaNovoJogoSinglePlayer(jogadorHumano);
+            partida = criaNovaPartidaSinglePlayer(jogadorHumano);
         }
         (new Thread(partida)).start();
         mIsViva = true;
     }
 
-    private Partida criaNovoJogoSinglePlayer(JogadorHumano humano) {
+    private Partida criaNovaPartidaSinglePlayer(JogadorHumano humano) {
         String modo = preferences.getString("modo", "P");
         boolean humanoDecide = preferences.getBoolean("humanoDecide", true);
         boolean jogoAutomatico = preferences.getBoolean("jogoAutomatico", false);
@@ -177,7 +177,7 @@ public class TrucoActivity extends Activity {
                     throw new RuntimeException(e);
                 }
             }
-            criaEIniciaNovoJogo();
+            criaEIniciaNovaPartida();
         }).start();
     }
 
@@ -197,7 +197,7 @@ public class TrucoActivity extends Activity {
 
     public void novaPartidaClickHandler(View v) {
         btnNovaPartida.setVisibility(View.INVISIBLE);
-        criaEIniciaNovoJogo();
+        criaEIniciaNovaPartida();
     }
 
     @Override
@@ -272,7 +272,7 @@ public class TrucoActivity extends Activity {
     protected void onDestroy() {
         super.onDestroy();
         mIsViva = false;
-        if (partida != null && !jogoAbortado) {
+        if (partida != null && !partidaAbortada) {
             partida.abandona(1);
         }
     }

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -109,6 +109,9 @@ public class TrucoActivity extends Activity {
      * diante pelo botão de nova partida.
      */
     private void criaEIniciaNovoJogo() {
+        preferences.edit().putInt("statPartidas",
+            preferences.getInt("statPartidas", 0) + 1
+        ).apply();
         jogadorHumano = new JogadorHumano(this, mesa);
         if (getIntent().hasExtra("multiplayer")) {
             partida = CriadorDePartida.criaNovaPartida(jogadorHumano);
@@ -406,6 +409,7 @@ public class TrucoActivity extends Activity {
             preferences.edit().putInt("statVitorias", vitorias).apply();
             preferences.edit().putInt("statDerrotas", derrotas).apply();
         }
+
         runOnUiThread(() -> {
             textViewPartidas.setText(vitorias + SEPARADOR_PLACAR_PARTIDAS + derrotas);
         });

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -272,6 +272,15 @@ public class TrucoActivity extends Activity {
     protected void onDestroy() {
         super.onDestroy();
         mIsViva = false;
+        // Se a Activity for fechada com uma partida em andamento, contabiliza a
+        // partida para a equipe adversária.
+        // Isso é relevante se o placar de partidas for persistente.
+        if (btnNovaPartida.getVisibility() != View.VISIBLE) {
+            int[] pontos = getPlacarDePartidas();
+            setPlacarDePartidas(pontos[0], pontos[1] + 1);
+        }
+        // Encerra qualquer partida em andamento (tanto para liberar recursos
+        // quanto para notificar os outros jogadores em jogo multiplayer)
         if (partida != null && !partidaAbortada) {
             partida.abandona(1);
         }

--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -161,6 +161,10 @@ public class TrucoActivity extends Activity {
         mesa.setTextoAumento(10, getString(R.string.botao_aumento_dez));
         mesa.setTextoAumento(12, getString(R.string.botao_aumento_doze));
 
+        findViewById(R.id.layoutPlacarPartidas).setOnClickListener(v -> {
+            onLimparPlacarDePartidasPressed();
+        });
+
         // O jogo só deve efetivamente iniciar quando a mesa estiver pronta
         new Thread(() -> {
             while (!mesa.isInicializada()) {
@@ -291,6 +295,33 @@ public class TrucoActivity extends Activity {
             .setView(dialogPerguntaAntesDeFechar)
             .setMessage("Você quer mesmo encerrar este jogo?")
             .setPositiveButton("Sim", (dialog, which) -> finish())
+            .setNegativeButton("Não", null)
+            .show();
+    }
+
+    public void onLimparPlacarDePartidasPressed() {
+
+        View dialogLimparSempre = getLayoutInflater()
+            .inflate(R.layout.dialog_sempre_limpa_placar_partidas, null);
+        final CheckBox checkBoxLimparSempre = dialogLimparSempre
+            .findViewById(R.id.checkBoxSempreLimpaPlacarPartidas);
+        checkBoxLimparSempre.setChecked(
+            preferences.getBoolean("sempreLimpaPlacarPartidas", false)
+        );
+
+        checkBoxLimparSempre.setOnCheckedChangeListener((button, isChecked) -> {
+            preferences.edit().putBoolean("sempreLimpaPlacarPartidas", isChecked).apply();
+        });
+
+        new AlertDialog.Builder(this)
+            .setIcon(android.R.drawable.ic_dialog_alert)
+            .setTitle("Limpar placar de partidas")
+            .setMessage("Você quer mesmo limpar o placar de partidas?")
+            .setView(dialogLimparSempre)
+            .setPositiveButton("Sim", (dialog, which) -> {
+//                partida.limpaPlacarDePartidas();
+//                atualizaPlacarDePartidas();
+            })
             .setNegativeButton("Não", null)
             .show();
     }

--- a/app/src/main/res/drawable/botao_limpar_placar.xml
+++ b/app/src/main/res/drawable/botao_limpar_placar.xml
@@ -1,0 +1,5 @@
+<vector android:height="15dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="15dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_sempre_confirma_fechar_jogo.xml
+++ b/app/src/main/res/layout/dialog_sempre_confirma_fechar_jogo.xml
@@ -8,6 +8,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:layout_marginVertical="4dp"
+        android:layout_marginHorizontal="18dp"
         android:checked="true"
         android:text="Sempre perguntar ao fechar um jogo" />
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_sempre_limpa_placar_partidas.xml
+++ b/app/src/main/res/layout/dialog_sempre_limpa_placar_partidas.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <CheckBox
+        android:id="@+id/checkBoxSempreLimpaPlacarPartidas"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:checked="false"
+        android:text="Sempre limpar o placar de partidas quando começar a jogar" />
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_sempre_limpa_placar_partidas.xml
+++ b/app/src/main/res/layout/dialog_sempre_limpa_placar_partidas.xml
@@ -8,6 +8,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:layout_marginVertical="4dp"
+        android:layout_marginHorizontal="18dp"
         android:checked="false"
         android:text="Sempre limpar o placar de partidas quando começar a jogar" />
 </LinearLayout>

--- a/app/src/main/res/layout/truco.xml
+++ b/app/src/main/res/layout/truco.xml
@@ -162,13 +162,25 @@
             android:background="@drawable/borda_placar"
             android:orientation="vertical">
 
-            <androidx.appcompat.widget.AppCompatTextView
+            <FrameLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="partidas"
-                android:textSize="11sp"
-                android:textColor="#000000" />
+                android:layout_height="wrap_content">
+
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:text="partidas"
+                    android:textColor="#000000"
+                    android:textSize="11sp" />
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="top|right"
+                    android:src="@drawable/botao_limpar_placar" />
+
+            </FrameLayout>
 
             <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/textViewPartidas"

--- a/app/src/main/res/xml/opcoes.xml
+++ b/app/src/main/res/xml/opcoes.xml
@@ -36,6 +36,11 @@
             android:key="humanoDecide"
             android:summary="Em jogo local, se esta opção estiver ligada, o parceiro bot não pode aceitar truco ou mão de 10/11. Ele só diz se iria, mas o humano é que decide"
             android:title="Humano decide pela dupla" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="limpaPlacarPartidas"
+            android:summary="Se esta opção estiver ligada, o placar de partidas é zerado sempre que um jogo local é iniciado"
+            android:title="Limpa placar de partidas" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Desenvolvimento (️☠=PRE-RI-GO, não mexa)">

--- a/app/src/test/java/me/chester/minitruco/android/JogadorHumanoTest.java
+++ b/app/src/test/java/me/chester/minitruco/android/JogadorHumanoTest.java
@@ -1,9 +1,7 @@
 package me.chester.minitruco.android;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -26,8 +24,6 @@ class JogadorHumanoTest {
 
     @Test
     void dizFraseDeVitoriaOuDerrotaNoFimDoJogo() {
-        doNothing().when(jogadorHumano).incrementaEstatistica(any());
-
         doReturn(1).when(jogadorHumano).getEquipe();
         jogadorHumano.jogoFechado(1, 0);
         jogadorHumano.jogoFechado(2, 0);


### PR DESCRIPTION
Implementa o placar persistente. No final ficou assim:

- Reutiliza os contadores antigos (galera vai tomar um susto de início, mas quem joga desde o início dos tempos vai curtir)
- Apenas em single player
- Pode limpar clicando no "x" (na verdade, em qualquer lugar do placar)
- Persistente por default
- Pode desliga/religar em opções e também no diálogo de confirmação
- Se o jogo for fechado antes de encerrar, conta como derrota

TODO:
- [ ] Esconder o X e desabilitar se for multiplayer
- [ ] Considerar a possibilidade de *não* ser persistente por default e/ou usar estatísticas novas

Closes #109 
Parte de #158 
