### PR TITLE
Não notifica abandono de partida se ela já acabou.

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -268,16 +268,13 @@ public class TrucoActivity extends Activity {
     protected void onDestroy() {
         super.onDestroy();
         mIsViva = false;
-        // Se a activity for fechada antes da finalização normal, contabiliza
-        // para a equipe adversária.
-        // Isso é relevante se o placar de partidas for persistente.
-        if (!partida.finalizada) {
+        if (partida != null && !partidaAbortada && !partida.finalizada) {
+            // Usuário fechou partida em andamento, contabiliza derrota
+            // (para o placar de partidas do single-player)...
             int[] pontos = getPlacarDePartidas();
             setPlacarDePartidas(pontos[0], pontos[1] + 1);
-        }
-        // Notifica o abandono da partida (caso outra pessoa já não tenha
-        // feito isso), avisando outros jogadores e encerrando a conexão/thread.
-        if (partida != null && !partidaAbortada) {
+            // ...e notifica os outros jogadores (para que todos voltem
+            // para a sala no multiplayer)
             partida.abandona(1);
         }
     }


### PR DESCRIPTION
Isso evita que a notificação `A`(bortar) fique no buffer do socket e seja consumida quando a nova partida começa (encerrando-a imediatamente).

Ainda tem um pequeno mishap: quando um cliente bluetooth fecha a activity, ele volta pra sala (tela dos nomes), mas os outros continuam esperando o servidor iniciar uma nova partida ou voltar pra mesa também. Mas pelo menos essas duas ações funcionam normalmente: se ele iniciar uma nova partida, o cliente é levado de volta à `TrucoActivity`, senão, vai todo mundo pra sala. Good enough for me.

Closes #166