### PR TITLE
Acrescenta checagens de `null` para evitar NPEs

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/MesaView.java
+++ b/app/src/main/java/me/chester/minitruco/android/MesaView.java
@@ -346,7 +346,7 @@ public class MesaView extends View {
                     cv.resetBitmap();
                     if (i >= 4) {
                         int numJogador = (i - 1) / 3;
-                        if (trucoActivity.partida.finalizada) {
+                        if (trucoActivity != null && trucoActivity.partida != null && trucoActivity.partida.finalizada) {
                             cv.movePara(leftBaralho, topBaralho);
                         } else if (cv.descartada) {
                             cv.movePara(calcPosLeftDescartada(numJogador), calcPosTopDescartada(numJogador));
@@ -394,7 +394,9 @@ public class MesaView extends View {
         aguardaFimAnimacoes();
         if (resultado != 3) {
             cartaQueFez = getCartaVisual(trucoActivity.partida.getCartasDaRodada(numRodada)[jogadorQueTorna.getPosicao() - 1]);
-            cartaQueFez.destacada = true;
+            if (cartaQueFez != null) {
+                cartaQueFez.destacada = true;
+            }
         }
         for (CartaVisual c : cartas) {
             c.escura = c.descartada;


### PR DESCRIPTION
Isso lida com três exceções encontradas na Play Store (e listadas em #175):

```
Exception java.lang.NullPointerException:
at me.chester.minitruco.android.MesaView.atualizaResultadoRodada (MesaView.java:397)
at me.chester.minitruco.android.JogadorHumano.rodadaFechada (JogadorHumano.java:166)
at me.chester.minitruco.android.multiplayer.PartidaRemota.processaNotificacao (PartidaRemota.java:214)
at me.chester.minitruco.android.multiplayer.bluetooth.ClienteBluetoothActivity.run (ClienteBluetoothActivity.java:123)
at java.lang.Thread.run (Thread.java:1012)
```
```
Exception java.lang.NullPointerException:
at me.chester.minitruco.android.MesaView.onSizeChanged (MesaView.java:349)
at android.view.View.sizeChange (View.java:23431)
```
```
Exception java.lang.NullPointerException:
at me.chester.minitruco.android.MesaView.atualizaResultadoRodada (MesaView.java:397)
at me.chester.minitruco.android.JogadorHumano.rodadaFechada (JogadorHumano.java:166)
at me.chester.minitruco.core.PartidaLocal.processaJogada (PartidaLocal.java:308)
at me.chester.minitruco.core.PartidaLocal.run (PartidaLocal.java:131)
at java.lang.Thread.run (Thread.java:1012)
```

(tecnicamente a 1a. e a 3a. são a mesma, chamadas de pontos diferentes).

Eu imagino que a condição em que esses objetos são `null` nesse ponto do código seja uma combinação raríssima de fatores, pela quantidade reduzida de ocorrências. De qualquer forma, em ambos os casos o que é afetado é o desenho de uma carta; possivelmente no(s) frame(s) seguintes o objeto já será substituído, então não deve haver dano (e se houver, é melhor que o jogo crashar, provavelmente).
