### PR TITLE
Sanitiza nomes dos jogadores no servidor internet

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 
 import me.chester.minitruco.BuildConfig;
 import me.chester.minitruco.android.JogadorHumano;
+import me.chester.minitruco.core.Jogador;
 import me.chester.minitruco.core.JogadorBot;
 import me.chester.minitruco.core.Partida;
 import me.chester.minitruco.core.PartidaLocal;
@@ -264,7 +265,7 @@ public class ServidorBluetoothActivity extends BaseBluetoothActivity {
     }
 
     private void inicializaDisplay() {
-        apelidos[0] = sanitizaNome(btAdapter.getName());
+        apelidos[0] = Jogador.sanitizaNome(btAdapter.getName());
         apelidos[1] = APELIDO_BOT;
         apelidos[2] = APELIDO_BOT;
         apelidos[3] = APELIDO_BOT;
@@ -376,7 +377,7 @@ public class ServidorBluetoothActivity extends BaseBluetoothActivity {
             if (connClientes[i] == null) {
                 connClientes[i] = socket;
                 outClientes[i] = socket.getOutputStream();
-                apelidos[i + 1] = sanitizaNome(socket.getRemoteDevice().getName());
+                apelidos[i + 1] = Jogador.sanitizaNome(socket.getRemoteDevice().getName());
                 status = i == 2 ? STATUS_LOTADO : STATUS_AGUARDANDO;
                 return i;
             }
@@ -417,13 +418,4 @@ public class ServidorBluetoothActivity extends BaseBluetoothActivity {
         atualizaClientes();
     }
 
-    public static String sanitizaNome(String nome) {
-        return (nome == null ? "" : nome)
-            .replaceAll("[-_ \r\n]"," ")
-            .trim()
-            .replaceAll("[^a-zA-Z0-9À-ÿ ]", "")
-            .trim()
-            .replaceAll(" +","_")
-            .replaceAll("^[-_ ]*$", "Jogador(a)");
-    }
 }

--- a/core/src/main/java/me/chester/minitruco/core/Jogador.java
+++ b/core/src/main/java/me/chester/minitruco/core/Jogador.java
@@ -34,6 +34,7 @@ public abstract class Jogador {
             .replaceAll("[^a-zA-Z0-9À-ÿ ]", "")
             .trim()
             .replaceAll(" +","_")
+            .replaceAll("^(.{0,25}).*$", "$1")
             .replaceAll("^[-_ ]*$", "Jogador(a)");
     }
 

--- a/core/src/main/java/me/chester/minitruco/core/Jogador.java
+++ b/core/src/main/java/me/chester/minitruco/core/Jogador.java
@@ -27,6 +27,16 @@ public abstract class Jogador {
      */
     protected Partida partida;
 
+    public static String sanitizaNome(String nome) {
+        return (nome == null ? "" : nome)
+            .replaceAll("[-_ \r\n]"," ")
+            .trim()
+            .replaceAll("[^a-zA-Z0-9À-ÿ ]", "")
+            .trim()
+            .replaceAll(" +","_")
+            .replaceAll("^[-_ ]*$", "Jogador(a)");
+    }
+
     /**
      * Processa o evento de entrada na partida (guardando a partida)
      */

--- a/core/src/main/java/me/chester/minitruco/core/Jogador.java
+++ b/core/src/main/java/me/chester/minitruco/core/Jogador.java
@@ -27,6 +27,13 @@ public abstract class Jogador {
      */
     protected Partida partida;
 
+    /**
+     * Garante que o nome do jogador tenha tamanho e caracteres seguros.
+     *
+     * @param nome Nome a ser sanitizado
+     * @return nome apenas com alfanuméricos acentuados, underscores e <= 25
+     *         caracteres; se não houverem caracteres válidos, nome default.
+     */
     public static String sanitizaNome(String nome) {
         return (nome == null ? "" : nome)
             .replaceAll("[-_ \r\n]"," ")
@@ -35,6 +42,7 @@ public abstract class Jogador {
             .trim()
             .replaceAll(" +","_")
             .replaceAll("^(.{0,25}).*$", "$1")
+            .replaceAll("_$","")
             .replaceAll("^[-_ ]*$", "Jogador(a)");
     }
 

--- a/core/src/test/java/me/chester/minitruco/core/JogadorTest.java
+++ b/core/src/test/java/me/chester/minitruco/core/JogadorTest.java
@@ -1,13 +1,13 @@
-package me.chester.minitruco.android.multiplayer.bluetooth;
+package me.chester.minitruco.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class ServidorBluetoothActivityTest {
+public class JogadorTest {
 
     private static String sanitizaNome(String nome) {
-        return ServidorBluetoothActivity.sanitizaNome(nome);
+        return Jogador.sanitizaNome(nome);
     }
 
     @Test

--- a/core/src/test/java/me/chester/minitruco/core/JogadorTest.java
+++ b/core/src/test/java/me/chester/minitruco/core/JogadorTest.java
@@ -53,5 +53,8 @@ public class JogadorTest {
             sanitizaNome("!!$$|1234567890123456789012345"));
         assertEquals("1234567890123456789012345",
             sanitizaNome("!!$$|1234567890123456789012345excesso"));
+        // Não deixa underscore no final se truncar no espaço
+        assertEquals("1234567890_234567890_234",
+            sanitizaNome("1234567890 234567890 234 6"));
     }
 }

--- a/core/src/test/java/me/chester/minitruco/core/JogadorTest.java
+++ b/core/src/test/java/me/chester/minitruco/core/JogadorTest.java
@@ -16,8 +16,8 @@ public class JogadorTest {
         assertEquals("Pixel_2_XL", sanitizaNome("Pixel 2 XL"));
         assertEquals("Kindle_Fire", sanitizaNome("Kindle Fire"));
         assertEquals("João_Da_Silva_123", sanitizaNome("João Da Silva_123"));
-        assertEquals("é_í_ó_ú_ã_õ_ç_á_à_â_ê_ô_ü_ñ", sanitizaNome("é í ó ú ã õ ç á à â ê ô ü ñ"));
-        assertEquals("É_Í_Ó_Ú_Ã_Õ_Ç_Á_À_Â_Ê_Ô_Ü_Ñ", sanitizaNome("É Í Ó Ú Ã Õ Ç Á À Â Ê Ô Ü Ñ"));
+        assertEquals("éíóúãõ_ç_á_à_â_ê_ô_ü_ñ", sanitizaNome("éíóúãõ ç á à â ê ô ü ñ"));
+        assertEquals("ÉÍÓÚÃÕ_Ç_Á_À_Â_Ê_Ô_Ü_Ñ", sanitizaNome("ÉÍÓÚÃÕ Ç Á À Â Ê Ô Ü Ñ"));
         assertEquals("Carlos_san", sanitizaNome("こんにちは, Carlos-san!"));
         assertEquals("Carlos", sanitizaNome("💩Carlos💩"));
         assertEquals("1_2_3_4", sanitizaNome("-1_2-3 4-"));
@@ -45,5 +45,13 @@ public class JogadorTest {
         assertEquals("Jogador(a)", sanitizaNome("-------"));
         assertEquals("Jogador(a)", sanitizaNome("💩"));
         assertEquals("Jogador(a)", sanitizaNome("誰かの名前を日本語で"));
+    }
+
+    @Test
+    void sanitizaNomeLimitaTamanhoEm25CaracteresValidos() {
+        assertEquals("1234567890123456789012345",
+            sanitizaNome("!!$$|1234567890123456789012345"));
+        assertEquals("1234567890123456789012345",
+            sanitizaNome("!!$$|1234567890123456789012345excesso"));
     }
 }

--- a/docs/desenvolvimento.md
+++ b/docs/desenvolvimento.md
@@ -219,7 +219,7 @@ TODO: instruções de como usar o servidor via terminal
 
 - `W`: recupera número de versão (e de repente outras infos no futuro)
 - `B <numero>`:  Informa o número do build do cliente, para que o servidor verifique compatibilidade
-- `N <apelido>`: Define o nome do jogador
+- `N <apelido>`: Define o nome do jogador (se for inválido, define o default)
 - `E PUB <modo>`: Entra em uma sala pública (criando, se não tiver nenhuma com vaga) com o modo especificado
 - `S`: - Sai da sala (encerrando a partida, se houver uma em andamento)
 - `Q`: - Quero Jogar
@@ -238,8 +238,6 @@ TODO: instruções de como usar o servidor via terminal
 - `X CI`: `Comando inválido
 - `X AI`: `Argumento inválido
 - `X FS`: `Você não está numa sala
-- `X NI`: `Nome inválido
-- `X NE`: `Nome já está em uso
 - `X NO`: `É preciso atribuir um nome para entrar na sala
 - `X JE sala`: `Você já está na sala de código `sala`
 - `N nome`: `Seu nome foi definido como `nome`

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -7,11 +7,21 @@ application {
 
 dependencies {
     implementation project(':core')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0-M1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0-M1'
+    testImplementation 'org.mockito:mockito-core:5.3.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.3.1'
 }
-
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 tasks.jar {

--- a/server/src/main/java/me/chester/minitruco/server/Comando.java
+++ b/server/src/main/java/me/chester/minitruco/server/Comando.java
@@ -3,6 +3,8 @@ package me.chester.minitruco.server;
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2005-2023 Carlos Duarte do Nascimento "Chester" <cd@pobox.com> */
 
+import java.lang.reflect.InvocationTargetException;
+
 /**
  * Superclasse de todos os comandos que podem ser emitidos por um cliente.
  * <p>
@@ -26,5 +28,42 @@ public abstract class Comando {
      * @param j    Jogador que solicitou o comando
      */
     public abstract void executa(String[] args, JogadorConectado j);
+
+    /**
+     * Interpreta uma linha de comando e executa com a classe apropriada
+     *
+     * @param linha comando recebido do cliente (ex.: "N Carlos" para "meu nome é Carlos")
+     * @param j Jogador que solicitou o comando
+     * @see /docs/desenvolvimento.md#protocolo-de-comunicação-multiplayer
+     */
+    public static void interpreta(String linha, JogadorConectado j) {
+        // Quebra a solicitação em tokens
+        String[] args = linha.split(" ");
+        if (args.length == 0 || args[0].length() == 0) {
+            return;
+        }
+
+        // Encontra a implementação do comando solicitado e chama
+        if (args[0].length() != 1) {
+            return;
+        }
+        char comando = Character.toUpperCase(args[0].charAt(0));
+        try {
+            Comando c = (Comando) Class.forName(
+                    "me.chester.minitruco.server.Comando"
+                            + comando).getDeclaredConstructor().newInstance();
+            c.executa(args, j);
+        } catch (ClassNotFoundException e) {
+            j.println("X CI");
+        } catch (InstantiationException e) {
+            j.println("X CI");
+        } catch (IllegalAccessException e) {
+            j.println("X CI");
+        } catch (InvocationTargetException e) {
+            j.println("X CI");
+        } catch (NoSuchMethodException e) {
+            j.println("X CI");
+        }
+    }
 
 }

--- a/server/src/main/java/me/chester/minitruco/server/Comando.java
+++ b/server/src/main/java/me/chester/minitruco/server/Comando.java
@@ -3,8 +3,6 @@ package me.chester.minitruco.server;
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2005-2023 Carlos Duarte do Nascimento "Chester" <cd@pobox.com> */
 
-import java.lang.reflect.InvocationTargetException;
-
 /**
  * Superclasse de todos os comandos que podem ser emitidos por um cliente.
  * <p>
@@ -37,32 +35,36 @@ public abstract class Comando {
      * @see /docs/desenvolvimento.md#protocolo-de-comunicação-multiplayer
      */
     public static void interpreta(String linha, JogadorConectado j) {
+        if (linha==null) return;
+        if (linha.isEmpty()) return;
+
         // Quebra a solicitação em tokens
         String[] args = linha.split(" ");
-        if (args.length == 0 || args[0].length() == 0) {
-            return;
-        }
+        if (args.length == 0) return;
+        if (args[0].length() != 1) return;
 
-        // Encontra a implementação do comando solicitado e chama
-        if (args[0].length() != 1) {
-            return;
-        }
-        char comando = Character.toUpperCase(args[0].charAt(0));
-        try {
-            Comando c = (Comando) Class.forName(
-                    "me.chester.minitruco.server.Comando"
-                            + comando).getDeclaredConstructor().newInstance();
+        char letraComando = Character.toUpperCase(args[0].charAt(0));
+        Comando c = comandoParaLetra(letraComando);
+        if (c != null) {
             c.executa(args, j);
-        } catch (ClassNotFoundException e) {
+        } else {
             j.println("X CI");
-        } catch (InstantiationException e) {
-            j.println("X CI");
-        } catch (IllegalAccessException e) {
-            j.println("X CI");
-        } catch (InvocationTargetException e) {
-            j.println("X CI");
-        } catch (NoSuchMethodException e) {
-            j.println("X CI");
+        }
+    }
+
+    /**
+     * Retorna uma instância da subclasse de Comando correspondente à letra
+     *
+     * @param letra um comando, sem parâmetros. Ex.: "N"
+     * @return instância da classe correspondente. Ex.: ComandoN
+     */
+    static Comando comandoParaLetra(char letra) {
+        try {
+            return (Comando) Class.forName(
+                "me.chester.minitruco.server.Comando"
+                    + letra).getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/server/src/main/java/me/chester/minitruco/server/ComandoN.java
+++ b/server/src/main/java/me/chester/minitruco/server/ComandoN.java
@@ -30,7 +30,6 @@ public class ComandoN extends Comando {
         String nome = Jogador.sanitizaNome(
             (comando + "  ").substring(2)
         );
-        // TODO limitar tamanho no sanitizador
         j.setNome(nome);
         j.println("N " + nome);
     }

--- a/server/src/main/java/me/chester/minitruco/server/ComandoN.java
+++ b/server/src/main/java/me/chester/minitruco/server/ComandoN.java
@@ -3,6 +3,8 @@ package me.chester.minitruco.server;
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2005-2023 Carlos Duarte do Nascimento "Chester" <cd@pobox.com> */
 
+import me.chester.minitruco.core.Jogador;
+
 /**
  * Atribui um nome ao jogador.
  * <p>
@@ -23,30 +25,12 @@ public class ComandoN extends Comando {
 
     @Override
     public void executa(String[] args, JogadorConectado j) {
-        String nome;
-        // Valida o apelido
-        try {
-            if (args == null || args[1].length() < 1 || args[1].length() > 50 || args[1].equals("unnamed")) {
-                j.println("X NI");
-                return;
-            }
-        } catch (Exception e) {
-            j.println("X NI");
-            return;
-        }
-        nome = args[1];
-        for (int i = 0; i < nome.length(); i++) {
-            char c = nome.charAt(i);
-            if (!(Character.isLetterOrDigit(c) || CARACTERES_PERMITIDOS
-                    .indexOf(c) != -1)) {
-                j.println("X NI");
-                return;
-            }
-        }
-        if (JogadorConectado.isNomeEmUso(nome)) {
-            j.println("X NE");
-            return;
-        }
+        // TODO a gente podia receber o comando também
+        String comando = String.join(" ", args);
+        String nome = Jogador.sanitizaNome(
+            (comando + "  ").substring(2)
+        );
+        // TODO limitar tamanho no sanitizador
         j.setNome(nome);
         j.println("N " + nome);
     }

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -7,7 +7,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.lang.reflect.InvocationTargetException;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.util.HashSet;
@@ -118,50 +117,20 @@ public class JogadorConectado extends Jogador implements Runnable {
             out = new PrintStream(cliente.getOutputStream());
             // Imprime info do servidor (como mensagem de boas-vindas)
             (new ComandoW()).executa(null, this);
-            while (true) {
-                String s = null;
+            String linha = "";
+            while (linha != null) {
                 try {
-                    s = in.readLine();
+                    linha = in.readLine();
+                    Comando.interpreta(linha, this);
                 } catch (SocketTimeoutException e) {
                     // A linha é só pra garantir que, no caso de uma conexão presa
-                    // o teste abaixo dela dê erro (seja no if, seja exception)
+                    // o teste abaixo dela dê erro (seja no if, seja exception no print)
                     println("");
                     if (!cliente.isConnected()) {
                         ServerLogger.evento("Desconexao detectada durante timeout");
                         return;
                     }
                     continue;
-                }
-                if (s == null) {
-                    // Desconexão
-                    return;
-                }
-                // Quebra a solicitação em tokens
-                String[] args = s.split(" ");
-                if (args.length == 0 || args[0].length() == 0) {
-                    continue;
-                }
-
-                // Encontra a implementação do comando solicitado e chama
-                if (args[0].length() != 1) {
-                    continue;
-                }
-                char comando = Character.toUpperCase(args[0].charAt(0));
-                try {
-                    Comando c = (Comando) Class.forName(
-                            "me.chester.minitruco.server.Comando"
-                                    + comando).getDeclaredConstructor().newInstance();
-                    c.executa(args, this);
-                } catch (ClassNotFoundException e) {
-                    println("X CI");
-                } catch (InstantiationException e) {
-                    println("X CI");
-                } catch (IllegalAccessException e) {
-                    println("X CI");
-                } catch (InvocationTargetException e) {
-                    println("X CI");
-                } catch (NoSuchMethodException e) {
-                    println("X CI");
                 }
             }
         } catch (IOException e) {

--- a/server/src/test/java/me/chester/minitruco/server/ComandoNTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/ComandoNTest.java
@@ -1,0 +1,31 @@
+package me.chester.minitruco.server;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ComandoNTest {
+
+    private static JogadorConectado jogadorConectado;
+
+    @BeforeAll
+    static void setUp() {
+        jogadorConectado = mock(JogadorConectado.class);
+    }
+
+    void verificaResposta(String linha, String resposta) {
+        Mockito.reset(jogadorConectado);
+        Comando.interpreta(linha, jogadorConectado);
+        verify(jogadorConectado).println(resposta);
+    }
+
+    @Test
+    void testNomesInvalidos() {
+        verificaResposta("N", "X NI");
+        verificaResposta("N ", "X NI");
+        verificaResposta("N !@#$", "X NI");
+    }
+}

--- a/server/src/test/java/me/chester/minitruco/server/ComandoNTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/ComandoNTest.java
@@ -1,5 +1,6 @@
 package me.chester.minitruco.server;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -19,13 +20,24 @@ class ComandoNTest {
     void verificaResposta(String linha, String resposta) {
         Mockito.reset(jogadorConectado);
         Comando.interpreta(linha, jogadorConectado);
-        verify(jogadorConectado).println(resposta);
+        verify(jogadorConectado).println(eq(resposta));
     }
 
     @Test
-    void testNomesInvalidos() {
-        verificaResposta("N", "X NI");
-        verificaResposta("N ", "X NI");
-        verificaResposta("N !@#$", "X NI");
+    void testNomesInvalidosViramNomeDefault() {
+        verificaResposta("N", "N Jogador(a)");
+        verificaResposta("N ", "N Jogador(a)");
+        verificaResposta("N !@#$", "N Jogador(a)");
+    }
+
+    @Test
+    void testSanitizaNome() {
+        verificaResposta("N joão do pulo 23!", "N joão_do_pulo_23");
+    }
+
+    @Test
+    void testAtribuiNome() {
+        Comando.interpreta("N joselito", jogadorConectado);
+        verify(jogadorConectado).setNome("joselito");
     }
 }

--- a/server/src/test/java/me/chester/minitruco/server/ComandoTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/ComandoTest.java
@@ -1,0 +1,48 @@
+package me.chester.minitruco.server;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.Test;
+
+class ComandoTest {
+
+    JogadorConectado jogador = mock(JogadorConectado.class);
+
+    @Test
+    void testComandoParaLetraEncontraAClasseCerta() {
+        assertInstanceOf(ComandoN.class , Comando.comandoParaLetra('N'));
+        assertInstanceOf(ComandoC.class , Comando.comandoParaLetra('C'));
+        assertNull(Comando.comandoParaLetra('Z'));
+        assertNull(Comando.comandoParaLetra('!'));
+    }
+
+    // Não consigo fazer isso rolar; estou quase achando que ou eu
+    // implemento toda a burocracia de um command pattern, ou consolido
+    // essas classes todas em uma só, e faço um switch case dentro dela.
+    //
+    // Por ora eu vou focar em escrever os testes necessários em arquivos
+    // separados que chamam Comando.executa.
+//    void testExecutaDelegaEPassaParâmetrosParaSubClasseApropriada() {
+//        ComandoN comandoN = spy(ComandoN.class);
+//        try (MockedStatic<Comando> comando = mockStatic(Comando.class)) {
+//            comando.when(() -> Comando.comandoParaLetra('N')).thenReturn(comandoN);
+//            Comando.interpreta("N foo bar baz", jogador);
+//            comando.verify(() -> Comando.comandoParaLetra('N'));
+//            verify(comandoN).executa(new String[]{"N", "foo", "bar", "baz"}, jogador);
+//        }
+//    }
+
+    @Test
+    void testExecutaIgnoraNullsELinhasVazias() {
+        Comando.interpreta(null, jogador);
+        verifyNoInteractions(jogador);
+        Comando.interpreta("", jogador);
+        verifyNoInteractions(jogador);
+        Comando.interpreta(" ", jogador);
+        verifyNoInteractions(jogador);
+    }
+
+}


### PR DESCRIPTION
Usa a mesma sanitização de nomes do servidor Bluetooth, acrescentando uma pequena melhoria no sanitizador (limita em 25 caracteres)

Aproveita pra separar a interpretação do comando de `JogadorHumano` e implementar testes no módulo `server` (avançando #47 

Parte de #173 
