### PR TITLE
Update sem downtime no servidor, parte 1

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -50,7 +50,7 @@ trap 'shutdown_suave_do_servidor; exit 0' SIGTERM
 
 while true; do
     inicia_servidor
-    inotifywait -e delete_self "$jar"
+    inotifywait -e modify "$jar"
     shutdown_suave_do_servidor
     while [ ! -e "$jar" ]; do
         sleep 1

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Inicia o servidor do miniTruco e monitora o JAR dele (que é deletado
+# e recriado pelo processo de deploy).
+#
+# Quando o JAR é deletado, o script envia um sinal SIGUSR1 para o servidor,
+# o que faz o servidor entrar em "shutdown suave" (libera a porta imediatamente,
+# mas finaliza as partidas em andamento antes de se auto-encerrar)
+#
+# Quando o JAR é recriado, o script inicia outra instância do servidor.
+#
+# Desta forma, o servidor pode ser atualizado sem interromper as partidas e
+# com downtime mínimo (apenas o tempo entre o clean e o build do JAR).
+
+if [ -z "$1" ]; then
+    echo "Erro: é necessário fornecer o caminho do arquivo JAR como parâmetro."
+    echo "Exemplo de uso: $0 /caminho/do/arquivo.jar"
+    exit 1
+fi
+
+jar="$1"
+servidor_pid=""
+
+inicia_servidor() {
+    java -jar "$jar" &
+    servidor_pid=$! # $! contém o PID do último processo em background
+}
+
+shutdown_suave_do_servidor() {
+    if [ -n "$servidor_pid" ]; then
+        echo "Enviando sinal SIGUSR1 para o servidor no PID: $servidor_pid"
+        kill -SIGUSR1 "$servidor_pid"
+    fi
+}
+
+servidor_em_execucao() {
+    if ps -p "$servidor_pid" >/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Se o launcher for finalizado, finaliza o servidor também
+trap 'shutdown_suave_do_servidor; exit 0' SIGTERM
+
+###### O script efetivamente começa aqui ######
+
+# Verifica se o arquivo JAR existe
+
+while true; do
+    inicia_servidor
+    inotifywait -e delete_self "$jar"
+    shutdown_suave_do_servidor
+    while [ ! -e "$jar" ]; do
+        sleep 1
+    done
+    sleep 2 # Para ter certeza que o jar foi completamente salvo
+done

--- a/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
+++ b/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
@@ -44,7 +44,7 @@ public class MiniTrucoServer {
 
         // Quando *todas* as threads encerrarem, loga o evento final
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            ServerLogger.evento("Servidor finalizando");
+            ServerLogger.evento("Servidor finalizado; JVM desligando. Tchau.");
         }));
 
         // A thread inicial termina por aqui, mas o servidor continua rodandno

--- a/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
+++ b/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
@@ -60,8 +60,9 @@ public class MiniTrucoServer {
      */
     public static void aceitaConexoes() {
         ServerLogger.evento("Servidor inicializado e escutando na porta " + PORTA_SERVIDOR);
+        ServerSocket s = null;
         try {
-            ServerSocket s = new ServerSocket(PORTA_SERVIDOR);
+            s = new ServerSocket(PORTA_SERVIDOR);
             // Vamos checar a cada 1s se recebemos um interrupt
             s.setSoTimeout(1000);
             while (true) {
@@ -80,8 +81,15 @@ public class MiniTrucoServer {
                 (new Thread(j)).start();
             }
         } catch (IOException e) {
-            ServerLogger.evento(e, "Erro de I/O no ServerSocket, saindo do programa");
+            ServerLogger.evento(e, "Erro de I/O no ServerSocket");
         } finally {
+            if (s != null) {
+                try {
+                    s.close();
+                } catch (IOException e) {
+                    ServerLogger.evento(e, "Erro de I/O ao fechar ServerSocket");
+                }
+            }
             ServerLogger.evento("Servidor não está mais escutando; aguardando finalização dos jogadores conectados.");
         }
     }


### PR DESCRIPTION
Este PR:
- Implementa um launcher que inicia o server.jar e monitora ele por mudanças; quando ele muda, manda um sinal para o processo atual (para que ele termine de tratar os clientes e saia quando eles desconectarem todos)
- Modifica o servidor para receber o sinal acima e parar de escutar conexões

Com isso já é possível fazer o restart "gentil" apenas dando o bulid. Fica faltando:

1) Quando receber o sinal, o servidor deve:
  - Mandar mensagem para todos os jogadores conectados avisando que houve atualização e eles serão desconectados (imediatamente ou assim que terminarem a partida, se estiverem em uma)
  - Desconectar jogadores que não estiverem em uma partida, até que estejam todos desconectados
2) Se algo der errado no envio do sigusr e o launcher cair, o servidor vai continuar rodando e escutando (impedindo novas instâncias de subirem); de repente pensar em algum cleanup ou timeout pra isso (talvez no startup do launcher mandar o sigusr1 pra qualquer processo que se pareça com um servidor desgarrado)?