### PR TITLE
Desconecta jogadores quando o servidor está sendo desligado

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.preference.PreferenceManager;
 
@@ -160,6 +161,15 @@ public class ClienteInternetActivity extends SalaActivity {
                 break;
             case 'K': // Keepalive, apenas temos que devolver a notificação como comando
                 enviaLinha(line);
+                break;
+            case '!': // Mensagem
+                if (line.length() > 4 && line.startsWith("! I ")) {
+                    runOnUiThread(() -> {
+                        Toast.makeText(getApplicationContext(),
+                            line.substring(4),
+                            Toast.LENGTH_LONG).show();
+                    });
+                }
                 break;
             case 'P': // Partida iniciada
                 iniciaTrucoActivitySePreciso();

--- a/docs/desenvolvimento.md
+++ b/docs/desenvolvimento.md
@@ -359,6 +359,9 @@ TODO colocar um exemplo de jogo aqui (GIF ou whatnot)
 - `H <jogador> <frase> _`: Informa que o jogador na posição acusou/recusou (_=T/F) mão de 10/11
 - `S`: Informa que o jogador saiu da sala
 - `K <numero>`: Keepalive - cliente deve responder igual, isto é, `K <numero>` para não ser desconectado (apenas internet)
+- `! <modo> <mensagem>`: Exibir mensagem para o cliente. Modos:
+  - `T`: exibir temporariamente (ex.: num toast Android). Podem vir outras mensagens/notificações e/ou o servidor pode desconectar em seguida; o cliente tem que lidar com isso.
+
 
 ## Estratégia dos bots
 

--- a/docs/desenvolvimento.md
+++ b/docs/desenvolvimento.md
@@ -360,7 +360,7 @@ TODO colocar um exemplo de jogo aqui (GIF ou whatnot)
 - `S`: Informa que o jogador saiu da sala
 - `K <numero>`: Keepalive - cliente deve responder igual, isto é, `K <numero>` para não ser desconectado (apenas internet)
 - `! <modo> <mensagem>`: Exibir mensagem para o cliente. Modos:
-  - `T`: exibir temporariamente (ex.: num toast Android). Podem vir outras mensagens/notificações e/ou o servidor pode desconectar em seguida; o cliente tem que lidar com isso.
+  - `I`: exibir imediatamente por alguns segundos (ex.: num toast Android). Podem vir outras mensagens/notificações e/ou o servidor pode desconectar em seguida; o cliente tem que lidar com isso.
 
 
 ## Estratégia dos bots

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -61,8 +61,8 @@ public class JogadorConectado extends Jogador implements Runnable {
      * @param linha linha de texto a enviar
      */
     public synchronized void println(String linha) {
-        out.print(linha);
-        out.print("\r\n");
+        out.println(linha);
+        out.flush();
         // Não fazemos log de keepalive
         if (!linha.startsWith("K")) {
             ServerLogger.evento(this, linha);

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -21,6 +21,7 @@ import me.chester.minitruco.core.Jogador;
  */
 public class JogadorConectado extends Jogador implements Runnable {
 
+    public static final int TEMPO_KEEPALIVE = 5000;
     private final Socket cliente;
 
     /**
@@ -33,17 +34,26 @@ public class JogadorConectado extends Jogador implements Runnable {
     public boolean querJogar = false;
 
     /**
-     * Timestamp da última vez que o jogador entrou na sala
+     * Sala em que o jogador se encontra (null se nenhuma)
+     */
+    private Sala sala;
+
+    /**
+     * Timestamp de quando o jogador entrou na sala
      */
     public Date timestampSala;
-
-    private Sala sala;
 
     /**
      * Buffer de saída do jogador (para onde devemos "printar" os resultados dos
      * comandos)
      */
     private PrintStream out;
+
+    /**
+     * Se true, notifica jogadores em partida de tempos em tempos que o servidor
+     * será desligado, e desconecta jogadores fora de partida.
+     */
+    public static boolean servidorSendoDesligado = false;
 
     /**
      * Cria um novo jogador
@@ -81,7 +91,7 @@ public class JogadorConectado extends Jogador implements Runnable {
             BufferedReader in = new BufferedReader(new InputStreamReader(
                     cliente.getInputStream()));
             out = new PrintStream(cliente.getOutputStream());
-            iniciaMonitorDeConexao();
+            iniciaThreadAuxiliar();
             // Imprime info do servidor (como mensagem de boas-vindas)
             (new ComandoW()).executa(null, this);
             String linha = "";
@@ -101,7 +111,6 @@ public class JogadorConectado extends Jogador implements Runnable {
         } catch (IOException e) {
             ServerLogger.evento(e, "Erro de I/O inesperado loop principal do jogador");
         } finally {
-            finalizaMonitorDeConexao();
             Sala s = getSala();
             // Se houver um jogo em andamento (e ainda tivermos comunicação), encerra
             Comando.interpreta("A", this);
@@ -117,6 +126,7 @@ public class JogadorConectado extends Jogador implements Runnable {
                 s.mandaInfoParaTodos();
                 ServerLogger.evento(this, "finalizou thread");
             }
+            finalizaThreadAuxiliar();
         }
 
     }
@@ -125,21 +135,40 @@ public class JogadorConectado extends Jogador implements Runnable {
     private Thread threadMonitorDeConexao;
 
     /**
-     * Configura uma thread para testar a conexão, que envia um keepalive
-     * para o cliente a cada 5 segundos.
-     * <p>
-     * Isso evita um timeout no cliente e permite desbloquear o readLine()
-     * sem depender do timeout do socket, que é pouco confiável.
+     * Configura uma thread que executa tarefas do jogador, tais como:
+     * <ul>
+     *     <li>Enviar um keepalive para o cliente a cada 5s (evitando
+     *         timeout e bloqueio do readLine())</li>
+     *     <li>Se o servidor estiver sendo desligado (porque uma versão
+     *         atualizada subiu), desconecta jogadores fora de partida
+     *         e mantém os outros informados enquanto durar a partida.</li>
+     * </ul>
      */
-    private void iniciaMonitorDeConexao() {
+    private void iniciaThreadAuxiliar() {
         Thread threadPrincipal = Thread.currentThread();
         threadMonitorDeConexao = new Thread(() -> {
             ServerLogger.evento(this, "Iniciando monitor de conexão");
+            boolean avisouServidorSendoDesligado = false;
             while (true) {
+                if (servidorSendoDesligado) {
+                    if (!jogando) {
+                        println("! I Servidor atualizado. Conecte novamente para jogar.");
+                        try {
+                            cliente.close();
+                        } catch (IOException e) {
+                            ServerLogger.evento(e, "Erro de I/O inesperado ao desconectar jogador");
+                        }
+                        threadPrincipal.interrupt();
+                        break;
+                    } else if (!avisouServidorSendoDesligado) {
+                        println("! I Servidor atualizado. Finalize esta partida e conecte novamente.");
+                        avisouServidorSendoDesligado = true;
+                    }
+                }
                 keepAlive = System.currentTimeMillis();
                 println("K " + keepAlive);
                 try {
-                    Thread.sleep(5000);
+                    Thread.sleep(TEMPO_KEEPALIVE);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
@@ -160,11 +189,10 @@ public class JogadorConectado extends Jogador implements Runnable {
         threadMonitorDeConexao.start();
     }
 
-    private void finalizaMonitorDeConexao() {
-        Thread t = threadMonitorDeConexao;
+    private void finalizaThreadAuxiliar() {
         if (threadMonitorDeConexao != null) {
             ServerLogger.evento("Interrompendo monitor de conexão");
-            t.interrupt();
+            threadMonitorDeConexao.interrupt();
         }
     }
 

--- a/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
+++ b/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
@@ -40,6 +40,8 @@ public class MiniTrucoServer {
         Signal.handle(new Signal("USR1"), signal -> {
             ServerLogger.evento("Recebido sinal USR1 - interrompendo threadAceitaConxoes");
             threadAceitaConexoes.interrupt();
+            ServerLogger.evento("Avisando jogadores conectados que o servidor está sendo desligado");
+            JogadorConectado.servidorSendoDesligado = true;
         });
 
         // Quando *todas* as threads encerrarem, loga o evento final

--- a/server/src/main/java/me/chester/minitruco/server/Sala.java
+++ b/server/src/main/java/me/chester/minitruco/server/Sala.java
@@ -302,8 +302,12 @@ public class Sala {
     }
 
     /**
-     * Inicia a partida (completando a mesa com bots), caso ela ainda
-     * não tenha iniciado e o jogador que solicitou seja o gerente.
+     * Inicia a partida (completando a mesa com bots), desde que:
+     * <ul>
+     *   <li>não haja uma partida em andamento</li>
+     *   <li>o solicitante seja o gerente</li>
+     *   <li>o servidor não esteja sendo desligado</li>
+     * </ul>
      *
      * @param solicitante Jogador que solicitou o início da partida.
      */
@@ -312,6 +316,9 @@ public class Sala {
             return;
         }
         if (solicitante != getGerente()) {
+            return;
+        }
+        if (JogadorConectado.servidorSendoDesligado) {
             return;
         }
         // Completa as posições vazias com bots

--- a/server/src/test/java/me/chester/minitruco/server/SalaTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/SalaTest.java
@@ -214,26 +214,67 @@ class SalaTest {
     }
 
     @Test
-    void testIniciaPartida() {
+    void testSalaInicializaSemPartida() {
         Sala s = new Sala(true, "P");
         assertNull(s.getPartida());
+    }
 
+   @Test
+   void testSalaNaoIniciaPartidaSozinha() {
+        Sala s = new Sala(true, "P");
+        s.adiciona(j1);
+        s.adiciona(j2);
+        s.adiciona(j3);
+        s.adiciona(j4);
+        assertNull(s.getPartida());
+    }
+
+    @Test
+    void testSalaNaoIniciaPartidaSeJogadorNaoEstiverNela() {
+        Sala s = new Sala(true, "P");
         s.iniciaPartida(j1);
-        assertNull(s.getPartida()); // Não está na sala
+        assertNull(s.getPartida());
+    }
 
+    @Test
+    void testSalaNaoIniciaPartidaSeJogadorNaoForGerente() {
+        Sala s = new Sala(true, "P");
         s.adiciona(j1);
         s.adiciona(j2);
 
+        assertEquals(s.getGerente(), j1);
         s.iniciaPartida(j2);
-        assertNull(s.getPartida()); // Não é o gerente
+        assertNull(s.getPartida());
+    }
+
+    @Test
+    void testSalaNaoIniciaPartidaSeJaHouverUmaEmAndamento() {
+        Sala s = new Sala(true, "P");
+        s.adiciona(j1);
+        s.adiciona(j2);
 
         s.iniciaPartida(j1);
-        assertNotNull(s.getPartida());
-
-        // Se já houver partida rolando, não inicia uma nova
         Partida p = s.getPartida();
+        assertEquals(p, s.getPartida());
+
         s.iniciaPartida(j1);
         assertEquals(p, s.getPartida());
+    }
+
+    @Test
+    void testSalaPodeIniciarNovaPartidaQuandoAPrimeiraFinaliza() {
+        Sala s = new Sala(true, "P");
+        s.adiciona(j1);
+        s.adiciona(j2);
+
+        s.iniciaPartida(j1);
+        Partida p = s.getPartida();
+
+        p.abandona(1);
+        assertNull(s.getPartida());
+        s.iniciaPartida(j1);
+        assertNotNull(s.getPartida());
+        assertNotEquals(p, s.getPartida());
     }
 
     @Test

--- a/server/src/test/java/me/chester/minitruco/server/SalaTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/SalaTest.java
@@ -261,8 +261,13 @@ class SalaTest {
         Sala s = new Sala(true, "P");
         s.adiciona(j1);
         s.adiciona(j2);
-        JogadorConectado.servidorSendoDesligado = true;
-        s.iniciaPartida(j1);
+        try {
+            JogadorConectado.servidorSendoDesligado = true;
+            s.iniciaPartida(j1);
+        } finally {
+            // Evita side effect em outros testes
+            JogadorConectado.servidorSendoDesligado = false;
+        }
         assertNull(s.getPartida());
     }
 

--- a/server/src/test/java/me/chester/minitruco/server/SalaTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/SalaTest.java
@@ -219,6 +219,15 @@ class SalaTest {
         assertNull(s.getPartida());
     }
 
+    @Test
+    void testIniciaPartida() {
+        Sala s = new Sala(true, "P");
+        s.adiciona(j1);
+        s.adiciona(j2);
+
+        s.iniciaPartida(j1);
+    }
+
    @Test
    void testSalaNaoIniciaPartidaSozinha() {
         Sala s = new Sala(true, "P");
@@ -244,6 +253,16 @@ class SalaTest {
 
         assertEquals(s.getGerente(), j1);
         s.iniciaPartida(j2);
+        assertNull(s.getPartida());
+    }
+
+    @Test
+    void testSalaNaoIniciaPartidaSeServidorEstiverSendoDesligado() {
+        Sala s = new Sala(true, "P");
+        s.adiciona(j1);
+        s.adiciona(j2);
+        JogadorConectado.servidorSendoDesligado = true;
+        s.iniciaPartida(j1);
         assertNull(s.getPartida());
     }
 


### PR DESCRIPTION
Esta PR:
- Implementa uma nova notificação, "!" (estava ficando sem letras), que faz o cliente mostrar um toast (que dá pouco tempo pra ler, mas pelo menos não se enrosca se a activity fechar)
- Quando o servidor está sendo finalizado:
  - todos os jogadores que estiverem numa partida são avisados de que serão desconectados ao final dela pela notificação acima
  - qualquer jogador que deixe de estar em uma partida é desconectado (e recebe um novo toast)

A thread de monitoração do keepalive foi refatorada em uma thread para tarefas de background como essa. 