### PR TITLE
Inicia jogo internet sempre pelo gerente

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TrucoActivity.java
@@ -361,7 +361,11 @@ public class TrucoActivity extends Activity {
             } else {
                 setPlacarDePartidas(pontos[0], pontos[1] + 1);
             }
-            if (partida.isHumanoGerente()) {
+            // Exibe o botão sempre no single-player (onde o humano está
+            // sempre na posição 1 da partida), e no multiplayer apenas
+            // se o jogador for o gerente da sala internet ou se for o
+            // servidor bluetooth (em ambos os casos, estará na posição 1).
+            if (jogadorHumano.getPosicao() == 1) {
                 btnNovaPartida.setVisibility(View.VISIBLE);
                 if (partida.isJogoAutomatico()) {
                     btnNovaPartida.performClick();

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/PartidaRemota.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/PartidaRemota.java
@@ -295,8 +295,8 @@ public class PartidaRemota extends Partida {
             // Cliente Bluetooth nunca é o gerente
             return false;
         } else {
-            // O servidor diz se o cliente internet é o gerente
-            return humanoGerente;
+            // Cliente Internet é o gerente se for o jogador na posição 1
+            return getJogadorHumano().getPosicao() == 1;
         }
     }
 

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/PartidaRemota.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/PartidaRemota.java
@@ -9,7 +9,6 @@ import java.util.logging.Logger;
 
 import me.chester.minitruco.android.JogadorHumano;
 import me.chester.minitruco.android.SalaActivity;
-import me.chester.minitruco.android.multiplayer.bluetooth.ClienteBluetoothActivity;
 import me.chester.minitruco.core.Baralho;
 import me.chester.minitruco.core.Carta;
 import me.chester.minitruco.core.Jogador;
@@ -282,22 +281,4 @@ public class PartidaRemota extends Partida {
             cliente.enviaLinha("A");
         }
     }
-
-    private boolean humanoGerente;
-
-    public void setHumanoGerente(boolean humanoGerente) {
-        this.humanoGerente = humanoGerente;
-    }
-
-    @Override
-    public boolean isHumanoGerente() {
-        if (cliente instanceof ClienteBluetoothActivity) {
-            // Cliente Bluetooth nunca é o gerente
-            return false;
-        } else {
-            // Cliente Internet é o gerente se for o jogador na posição 1
-            return getJogadorHumano().getPosicao() == 1;
-        }
-    }
-
 }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -44,7 +44,6 @@ public class ClienteInternetActivity extends SalaActivity {
     private PartidaRemota partida;
     private String modo;
     private int posJogador;
-    private boolean humanoGerente;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -153,10 +152,8 @@ public class ClienteInternetActivity extends SalaActivity {
                     p = (p + 1) % 4;
                     ((TextView) findViewById(R.id.textViewJogador4)).setText(nomes[p]);
                     modo = tokens[3];
-                    int posGerente = Integer.parseInt(tokens[4]);
-                    humanoGerente = (posGerente == posJogador);
                     findViewById(R.id.layoutIniciar).setVisibility(
-                        humanoGerente ? View.VISIBLE : View.GONE);
+                        posJogador == 1 ? View.VISIBLE : View.GONE);
                 });
                 break;
             case 'X': // Erro tratável
@@ -208,7 +205,6 @@ public class ClienteInternetActivity extends SalaActivity {
     public Partida criaNovaPartida(JogadorHumano jogadorHumano) {
         enviaLinha("Q");
         partida = new PartidaRemota(this, jogadorHumano, posJogador, modo);
-        partida.setHumanoGerente(humanoGerente);
         return partida;
     }
 

--- a/core/src/main/java/me/chester/minitruco/core/Partida.java
+++ b/core/src/main/java/me/chester/minitruco/core/Partida.java
@@ -345,14 +345,6 @@ public abstract class Partida implements Runnable {
     }
 
     /**
-     * Caso esta partida esteja rodando em um celular, diz se o jogador humano
-     * pode iniciar uma nova partida ao final da atual.
-     *
-     * @return true se o jogador humano é o gerente da partida, false se não
-     */
-    public abstract boolean isHumanoGerente();
-
-    /**
      * Retorna o nome usado para um determinado valor quando estamos pedindo aumento
      * de aposta. Por exemplo, 3 (no truco paulista) ou 4 (no truco mineiro)
      * se chamam "truco".

--- a/core/src/main/java/me/chester/minitruco/core/PartidaLocal.java
+++ b/core/src/main/java/me/chester/minitruco/core/PartidaLocal.java
@@ -722,12 +722,4 @@ public class PartidaLocal extends Partida {
     public boolean isJogoAutomatico() {
         return jogoAutomatico;
     }
-
-    @Override
-    public boolean isHumanoGerente() {
-        // Se estamos num celular, das duas uma: ou é um jogo single-player,
-        // ou o servidor Bluetooth (em ambos os casos, o humano é o gerente)
-        return true;
-    }
-
 }

--- a/docs/documentacao-para-desenvolvimento.md
+++ b/docs/documentacao-para-desenvolvimento.md
@@ -173,9 +173,11 @@ Essa separação radical de classes simplifica os jogadores (`JogadorHumano` nã
 
 É importante observar que o jogo multiplayer introduz algumas complexidades para entender a motivação da arquitetura de classes mais complexa:
 
-O jogo multiplayer pode acontecer via Bluetooth ou pela internet. Do ponto de vista do usuário, os jogadores entram em uma "sala de jogo". Um deles (o "gerente") pode mudar os outros de lugar e é quem pode iniciar uma nova partida (tanto a partir da sala de jogo, quanto no botão "Nova Partida" que aparece quando uma se encerra).
+O jogo multiplayer pode acontecer via Bluetooth ou pela internet. Quando um jogador se conecta no servidor internet, inicia um jogo Bluetooth ou se conecta no jogo iniciado pelo coleguinha, ele visualiza uma "sala de jogo", com os nomes nas posições do baralho.
 
-Todos os aparelhos enxergam a mesa do seu ponto de vista, ou seja, se temos os jogadores A, B, C e D, com B à direita de A, C à direita de B e D à direita de C, o jogador A vê a mesa assim:
+Isso já tem uma consequência: como todos os aparelhos enxergam a mesa do seu ponto de vista, a posição do jogador na sala/partida pode não bater com a "posição" visual, como definida acima (1 = inferior, 2 = esquerda, 3 = superior, 4 = direita).
+
+Por exemplo, digamos que temos os jogadores A, B, C e D nas posições 1, 2, 3 e 4 da partida, respectivamente, o jogador A vai exibir a mesa conforme esperado:
 
 ```
   C
@@ -185,7 +187,7 @@ D    B
   A
 ```
 
-mas o jogador B vê assim:
+mas o jogador B vai exibir assim (que é como ele enxerga):
 
 ```
   D
@@ -194,6 +196,10 @@ A    C
 
   B
 ```
+
+Na partida, o jogador A está na posição 1 em todos os aparelhos, o B está na posição 2, etc.; mas é responsabilidade do `MesaView` identificar a posição do jogador local (que é sempre uma instância de `JogadorHumano`) e "traduzir" as posições para exibir baralho, cartas jogadas, balões, etc.
+
+Em qualquer modalidade (single ou multiplayer), o jogador na posição 1 é especial (chamamos ele de "gerente"); ele é o único que pode reposicionar os outros jogadores e iniciar partidas (a partir da sala, ou quando a partida finaliza).
 
 #### Implementação
 
@@ -287,7 +293,7 @@ Você pode jogar via nc ou telnet. Para isso:
 
 4) Cada jogador deve se identificar com um nome, enviando um comando `N` (ex.: `N joselito`), entrar em uma sala com as regras desejadas (ex.: `E PUB P`)
 
-5) O gerente (primeiro jogador a entrar na sala) inicia o jogo com `Q`
+5) O gerente (jogador na posição 1 da sala) inicia o jogo com `Q`
 
 6) Dali pra frente é observar as notificações enviadas e os comandos apropriados. Veja a lista completa abaixo.
 
@@ -341,7 +347,7 @@ TODO colocar um exemplo de jogo aqui (GIF ou whatnot)
 - `X NO`: `É preciso atribuir um nome para entrar na sala
 - `X JE sala`: Você já está na sala de código `sala`
 - `N nome`: Seu nome foi definido como `nome`
-- `I <apelidos> <modo> <jogador> <gerente>`: Info da sala. `<jogador>` é a posição do cliente. `<gerente>` é a posição do gerente (só no jogo internet)
+- `I <apelidos> <modo> <jogador>`: Info da sala. `<jogador>` é a posição do cliente.
 - `P <jogador>`: Início da partida
 - `M <carta> <carta> <carta> <carta>`: Início da mão. Suas cartas são as três primeiras. A última, se houver, é o vira.
 - `V <jogador> _`: vez da pessoa na posição indicada. _ = T se pode jogar fechada, false se não pode

--- a/server/src/main/java/me/chester/minitruco/server/ComandoB.java
+++ b/server/src/main/java/me/chester/minitruco/server/ComandoB.java
@@ -1,5 +1,8 @@
 package me.chester.minitruco.server;
 
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright © 2005-2023 Carlos Duarte do Nascimento "Chester" <cd@pobox.com> */
+
 /**
  * Pergunta ao servidor se o cliente é compatível ou precisa de atualização.
  * <p>

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.Socket;
-import java.util.Date;
 
 import me.chester.minitruco.core.Carta;
 import me.chester.minitruco.core.Jogador;
@@ -33,11 +32,6 @@ public class JogadorConectado extends Jogador implements Runnable {
      * Sala em que o jogador se encontra (null se nenhuma)
      */
     private Sala sala;
-
-    /**
-     * Timestamp de quando o jogador entrou na sala
-     */
-    public Date timestampSala;
 
     /**
      * Buffer de saída do jogador (para onde devemos "printar" os resultados dos

--- a/server/src/main/java/me/chester/minitruco/server/Sala.java
+++ b/server/src/main/java/me/chester/minitruco/server/Sala.java
@@ -113,7 +113,8 @@ public class Sala {
     }
 
     /**
-     * Adiciona um jogador na sala, garantindo os links bidirecionais e, se necessário,
+     * Adiciona um jogador na primeira posição disponível da sala,
+     * garantindo os links bidirecionais e, se necessário,
      * trocando entre a lista das lotadas e das disponíveis.
      *
      * @param j Jogador a adicionar
@@ -183,9 +184,13 @@ public class Sala {
     }
 
     /**
-     * Remove um jogador da sala.
+     * Remove um jogador da sala, rompendo os links bidirecionais e atualizando
+     * as listas de salas.
      * <p>
-     * Se houver um partida em andamento, interrompe o mesmo.
+     * Se houver um partida em andamento, interrompe a mesma.
+     * <p>
+     * A sala é rotacionada de forma que o jogador mais antigo (e, portanto,
+     * o gerente) esteja na posição 1.
      *
      * @param j Jogador a remover
      * @return true se removeu, false se ele não estava lá
@@ -202,6 +207,14 @@ public class Sala {
                 jogadores[i] = null;
                 // Desfaz link jogador->sala
                 j.setSala(null);
+                // Se a posição 1 ficou vazia (mas ainda tem gente na sala),
+                // rotaciona até que alguém a ocupe (será o novo gerente)
+                while (getNumPessoas() > 0 && jogadores[0] == null) {
+                    for (int x = 1; x <= 3; x++) {
+                        jogadores[x - 1] = jogadores[x];
+                        jogadores[x] = null;
+                    }
+                }
                 atualizaColecoesDeSalas();
                 return true;
             }

--- a/server/src/main/java/me/chester/minitruco/server/Sala.java
+++ b/server/src/main/java/me/chester/minitruco/server/Sala.java
@@ -61,7 +61,8 @@ public class Sala {
     final String modo;
 
     /**
-     * Jogadores presentes na sala
+     * Jogadores presentes na sala; as posições 1 a 4 são os índices 0 a 3,
+     * e a posição 1 (índice 0) é o gerente da sala.
      */
     private Jogador[] jogadores = new Jogador[4];
 
@@ -139,24 +140,13 @@ public class Sala {
     }
 
     /**
-     * Recupera o gerente da sala, i.e., o <code>JogadorRemoto</code> mais
-     * antigo nela
+     * Recupera o gerente da sala (o jogador que pode trocar/inverter posições
+     * e iniciar a partida)
      *
-     * @return Jogador mais antigo, ou null se a sala não tiver jogadores
-     * remotos
+     * @return `JogadorConectado` na posição 1, ou null se a sala estiver vazia
      */
     public synchronized Jogador getGerente() {
-        JogadorConectado g = null;
-        for (int i = 0; i <= 3; i++) {
-            if (!(jogadores[i] instanceof JogadorConectado)) {
-                continue;
-            }
-            JogadorConectado j = (JogadorConectado) jogadores[i];
-            if (g == null || j.timestampSala.before(g.timestampSala)) {
-                g = j;
-            }
-        }
-        return g;
+        return jogadores[0];
     }
 
     /**

--- a/server/src/main/java/me/chester/minitruco/server/Sala.java
+++ b/server/src/main/java/me/chester/minitruco/server/Sala.java
@@ -3,10 +3,8 @@ package me.chester.minitruco.server;
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2005-2023 Carlos Duarte do Nascimento "Chester" <cd@pobox.com> */
 
-import static java.lang.Thread.sleep;
 import static me.chester.minitruco.core.JogadorBot.APELIDO_BOT;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -129,15 +127,8 @@ public class Sala {
         // Procura um lugarzinho na sala. Se achar, adiciona
         for (int i = 0; i <= 3; i++) {
             if (jogadores[i] == null) {
-                // Garante timestamps diferentes (Date tem resolução de 1ms)
-                try {
-                    sleep(1);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
                 // Link sala->jogador
                 jogadores[i] = j;
-                j.timestampSala = new Date();
                 // Link jogador->sala
                 j.setSala(this);
                 atualizaColecoesDeSalas();

--- a/server/src/main/java/me/chester/minitruco/server/Sala.java
+++ b/server/src/main/java/me/chester/minitruco/server/Sala.java
@@ -276,10 +276,6 @@ public class Sala {
 
         // Modo de partida
         sb.append(modo);
-        sb.append(' ');
-
-        // Posição do gerente
-        sb.append(getPosicao(getGerente()));
 
         return sb.toString();
     }

--- a/server/src/main/java/me/chester/minitruco/server/Sala.java
+++ b/server/src/main/java/me/chester/minitruco/server/Sala.java
@@ -35,6 +35,11 @@ public class Sala {
 
     private static final Set<Sala> salasPublicasLotadas = new HashSet<>();
 
+    /**
+     * Limpa todas as salas, interrompendo as partidas e removendo os jogadores.
+     * <p>
+     * Usada mais para evitar efeitos colaterais entre testes.
+     */
     public static void limpaSalas() {
         Set<Sala> todasAsSalas = new HashSet<>();
         todasAsSalas.addAll(salasPrivadas.values());
@@ -45,7 +50,7 @@ public class Sala {
             if (partida != null) {
                 partida.abandona(0);
             }
-            for (Jogador j : sala.jogadores) {
+            for (Jogador j : sala.jogadores.clone()) {
                 if (j instanceof JogadorConectado) {
                     sala.remove((JogadorConectado) j);
                 }

--- a/server/src/test/java/me/chester/minitruco/server/ComandoRTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/ComandoRTest.java
@@ -37,17 +37,17 @@ class ComandoRTest {
     @Test
     void testTrocaParceirosDoGerente() {
         Comando.interpreta("R T", j1);
-        verify(j1).println("I j1|j3|bot|j2 1 P 1");
-        verify(j2).println("I j1|j3|bot|j2 4 P 1");
-        verify(j3).println("I j1|j3|bot|j2 2 P 1");
+        verify(j1).println("I j1|j3|bot|j2 1 P");
+        verify(j2).println("I j1|j3|bot|j2 4 P");
+        verify(j3).println("I j1|j3|bot|j2 2 P");
     }
 
     @Test
     void testInverteAdversariosDoGerente() {
         Comando.interpreta("R I", j1);
-        verify(j1).println("I j1|bot|j3|j2 1 P 1");
-        verify(j2).println("I j1|bot|j3|j2 4 P 1");
-        verify(j3).println("I j1|bot|j3|j2 3 P 1");
+        verify(j1).println("I j1|bot|j3|j2 1 P");
+        verify(j2).println("I j1|bot|j3|j2 4 P");
+        verify(j3).println("I j1|bot|j3|j2 3 P");
     }
 
     @Test

--- a/server/src/test/java/me/chester/minitruco/server/SalaTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/SalaTest.java
@@ -37,7 +37,7 @@ class SalaTest {
         assertArrayEquals(esperados, reais);
     }
 
-    private Sala criaSalaComGerenteNaPosicao1() {
+    private Sala criaSalaCheiaComJj1Gerente() {
         Sala sala = new Sala(true, "P");
         sala.adiciona(jj1);
         sala.adiciona(jj2);
@@ -45,15 +45,6 @@ class SalaTest {
         sala.adiciona(jj4);
         assertPosicoes(sala, jj1, jj2, jj3, jj4);
         assertEquals(jj1, sala.getGerente());
-        return sala;
-    }
-
-    private Sala criaSalaComGerenteNaPosicao2() {
-        Sala sala = criaSalaComGerenteNaPosicao1();
-        sala.remove(jj1);
-        sala.adiciona(jj1);
-        assertPosicoes(sala, jj1, jj2, jj3, jj4);
-        assertEquals(jj2, sala.getGerente());
         return sala;
     }
 
@@ -96,22 +87,8 @@ class SalaTest {
         doNothing().when(jj4).println(any());
     }
 
-    // Isso é importante para não haver ambiguidade sobre
-    // quem é o gerente da sala
     @Test
-    void testAdicionaUsaTimestampsSequenciais() {
-        Sala s = new Sala(true, "P");
-        s.adiciona(j1);
-        s.adiciona(j2);
-        s.adiciona(j3);
-        s.adiciona(j4);
-        assertTrue(j1.timestampSala.before(j2.timestampSala));
-        assertTrue(j2.timestampSala.before(j3.timestampSala));
-        assertTrue(j3.timestampSala.before(j4.timestampSala));
-    }
-
-    @Test
-    void testGerenteÉSempreOUsuarioMaisAntigoNaSala() {
+    void testGerenteÉSempreOUsuarioNaPosicao1() {
         Sala s = new Sala(true, "P");
         assertNull(s.getGerente());
         s.adiciona(j1);
@@ -129,16 +106,16 @@ class SalaTest {
         s.adiciona(j3);
         assertEquals(j2, s.getGerente());
         s.remove(j2);
-        assertEquals(j4, s.getGerente());
-        s.remove(j4);
         assertEquals(j3, s.getGerente());
         s.remove(j3);
+        assertEquals(j4, s.getGerente());
+        s.remove(j4);
         assertNull(s.getGerente());
     }
 
     @Test
     void testRemoveMantemPosicao1PreenchidaSemAlterarPosicoesRelativas() {
-        Sala s = criaSalaComGerenteNaPosicao1();
+        Sala s = criaSalaCheiaComJj1Gerente();
         assertPosicoes(s, jj1, jj2, jj3, jj4);
         s.remove(jj3);
         assertPosicoes(s, jj1, jj2, null, jj4);
@@ -153,7 +130,7 @@ class SalaTest {
 
     @Test
     void testRemoveUltimoJogador() {
-        Sala s = criaSalaComGerenteNaPosicao1();
+        Sala s = criaSalaCheiaComJj1Gerente();
         s.remove(jj1);
         s.remove(jj2);
         s.remove(jj3);
@@ -234,7 +211,7 @@ class SalaTest {
         s.adiciona(j3);
         assertEquals("I john|paul|george|bot $POSICAO P 1", s.getInfo());
         s.remove(j1);
-        assertEquals("I bot|paul|george|bot $POSICAO P 2", s.getInfo());
+        assertEquals("I paul|george|bot|bot $POSICAO P 1", s.getInfo());
     }
 
     @Test
@@ -327,7 +304,7 @@ class SalaTest {
 
     @Test
     void testTrocaParceiroSimplesRetornaTrueETroca() {
-        Sala s = criaSalaComGerenteNaPosicao1();
+        Sala s = criaSalaCheiaComJj1Gerente();
         assertPosicoes(s, jj1, jj2, jj3, jj4);
         assertTrue(s.trocaParceiro(jj1));
         assertPosicoes(s, jj1, jj3, jj4, jj2);
@@ -335,15 +312,15 @@ class SalaTest {
 
     @Test
     void testTrocaParceiroRetornaFalseEIgnoraSeNaoForGerente() {
-        Sala s = criaSalaComGerenteNaPosicao2();
+        Sala s = criaSalaCheiaComJj1Gerente();
         assertPosicoes(s, jj1, jj2, jj3, jj4);
-        assertFalse(s.trocaParceiro(jj1));
+        assertFalse(s.trocaParceiro(jj2));
         assertPosicoes(s, jj1, jj2, jj3, jj4);
     }
 
     @Test
     void testTrocaParceiroRetornaFalseEIgnoraSeEstiverJogando() {
-        Sala s = criaSalaComGerenteNaPosicao1();
+        Sala s = criaSalaCheiaComJj1Gerente();
         s.iniciaPartida(jj1);
         assertPosicoes(s, jj1, jj2, jj3, jj4);
         assertFalse(s.trocaParceiro(jj1));
@@ -352,69 +329,63 @@ class SalaTest {
 
     @Test
     void testTrocaParceiroNaoAlteraQuemÉOGerente() {
-        Sala s = criaSalaComGerenteNaPosicao2();
-        assertEquals(jj2, s.getGerente());
-        s.trocaParceiro(jj2);
-        assertEquals(jj2, s.getGerente());
-    }
-
-    @Test
-    void testTrocaParceiroComGerenteNaPosicao2() {
-        Sala s = criaSalaComGerenteNaPosicao2();
-        assertPosicoes(s, jj1, jj2, jj3, jj4);
-        s.trocaParceiro(jj2);
-        assertPosicoes(s, jj3, jj2, jj4, jj1);
-        s.trocaParceiro(jj2);
-        assertPosicoes(s, jj4, jj2, jj1, jj3);
-        s.trocaParceiro(jj2);
-        assertPosicoes(s, jj1, jj2, jj3, jj4);
+        Sala s = criaSalaCheiaComJj1Gerente();
+        assertEquals(jj1, s.getGerente());
+        s.trocaParceiro(jj1);
+        assertEquals(jj1, s.getGerente());
     }
 
     @Test
     void testTrocaParceiroEmSalaComVaga() {
-        Sala s = criaSalaComGerenteNaPosicao2();
+        Sala s = criaSalaCheiaComJj1Gerente();
         s.remove(jj3);
         assertPosicoes(s, jj1, jj2, null, jj4);
-        s.trocaParceiro(jj2);
-        assertPosicoes(s, null, jj2, jj4, jj1);
-        s.trocaParceiro(jj2);
-        assertPosicoes(s, jj4, jj2, jj1, null);
-        s.trocaParceiro(jj2);
+        s.trocaParceiro(jj1);
+        assertPosicoes(s, jj1, null, jj4, jj2);
+        s.trocaParceiro(jj1);
+        assertPosicoes(s, jj1, jj4, jj2, null);
+        s.trocaParceiro(jj1);
         assertPosicoes(s, jj1, jj2, null, jj4);
+    }
+
+    @Test
+    void testTrocaParceiroEmSalaComDuasVagas() {
+        Sala s = criaSalaCheiaComJj1Gerente();
+        s.remove(jj2);
+        s.remove(jj4);
+        assertPosicoes(s, jj1, null, jj3, null);
+        s.trocaParceiro(jj1);
+        assertPosicoes(s, jj1, jj3, null, null);
+        s.trocaParceiro(jj1);
+        assertPosicoes(s, jj1, null, null, jj3);
+        s.trocaParceiro(jj1);
+        assertPosicoes(s, jj1, null, jj3, null);
     }
 
     @Test
     void testInverteAdversariosSimplesRetornaTrueEInverte() {
-        Sala s = criaSalaComGerenteNaPosicao1();
+        Sala s = criaSalaCheiaComJj1Gerente();
         assertPosicoes(s, jj1, jj2, jj3, jj4);
         assertTrue(s.inverteAdversarios(jj1));
         assertPosicoes(s, jj1, jj4, jj3, jj2);
+        assertTrue(s.inverteAdversarios(jj1));
+        assertPosicoes(s, jj1, jj2, jj3, jj4);
     }
 
     @Test
     void testInverteAdversariosRetornaFalseEIgnoraSeNaoForGerente() {
-        Sala s = criaSalaComGerenteNaPosicao2();
+        Sala s = criaSalaCheiaComJj1Gerente();
         assertPosicoes(s, jj1, jj2, jj3, jj4);
-        assertFalse(s.inverteAdversarios(jj1));
+        assertFalse(s.inverteAdversarios(jj2));
         assertPosicoes(s, jj1, jj2, jj3, jj4);
     }
 
     @Test
     void testInverteAdversariosRetornaFalseEIgnoraSeEstiverJogando() {
-        Sala s = criaSalaComGerenteNaPosicao1();
+        Sala s = criaSalaCheiaComJj1Gerente();
         s.iniciaPartida(jj1);
         assertPosicoes(s, jj1, jj2, jj3, jj4);
         assertFalse(s.inverteAdversarios(jj1));
-        assertPosicoes(s, jj1, jj2, jj3, jj4);
-    }
-
-    @Test
-    void testInverteAdversariosComGerenteNaPosicao2() {
-        Sala s = criaSalaComGerenteNaPosicao2();
-        assertPosicoes(s, jj1, jj2, jj3, jj4);
-        s.inverteAdversarios(jj2);
-        assertPosicoes(s, jj3, jj2, jj1, jj4);
-        s.inverteAdversarios(jj2);
         assertPosicoes(s, jj1, jj2, jj3, jj4);
     }
 }

--- a/server/src/test/java/me/chester/minitruco/server/SalaTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/SalaTest.java
@@ -137,6 +137,31 @@ class SalaTest {
     }
 
     @Test
+    void testRemoveMantemPosicao1PreenchidaSemAlterarPosicoesRelativas() {
+        Sala s = criaSalaComGerenteNaPosicao1();
+        assertPosicoes(s, jj1, jj2, jj3, jj4);
+        s.remove(jj3);
+        assertPosicoes(s, jj1, jj2, null, jj4);
+        s.remove(jj1);
+        assertPosicoes(s, jj2, null, jj4, null);
+        s.adiciona(jj1);
+        s.adiciona(jj3);
+        assertPosicoes(s, jj2, jj1, jj4, jj3);
+        s.remove(jj2);
+        assertPosicoes(s, jj1, jj4, jj3, null);
+    }
+
+    @Test
+    void testRemoveUltimoJogador() {
+        Sala s = criaSalaComGerenteNaPosicao1();
+        s.remove(jj1);
+        s.remove(jj2);
+        s.remove(jj3);
+        s.remove(jj4);
+        assertPosicoes(s, null, null, null, null);
+    }
+
+    @Test
     void testColocaEmSalaPublicaRetornaSalaDeDestino() {
         Sala s = Sala.colocaEmSalaPublica(j1, "P");
         assertEquals(s, j1.getSala());
@@ -382,8 +407,6 @@ class SalaTest {
         assertFalse(s.inverteAdversarios(jj1));
         assertPosicoes(s, jj1, jj2, jj3, jj4);
     }
-
-
 
     @Test
     void testInverteAdversariosComGerenteNaPosicao2() {

--- a/server/src/test/java/me/chester/minitruco/server/SalaTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/SalaTest.java
@@ -209,9 +209,9 @@ class SalaTest {
         s.adiciona(j1);
         s.adiciona(j2);
         s.adiciona(j3);
-        assertEquals("I john|paul|george|bot $POSICAO P 1", s.getInfo());
+        assertEquals("I john|paul|george|bot $POSICAO P", s.getInfo());
         s.remove(j1);
-        assertEquals("I paul|george|bot|bot $POSICAO P 1", s.getInfo());
+        assertEquals("I paul|george|bot|bot $POSICAO P", s.getInfo());
     }
 
     @Test


### PR DESCRIPTION
Para isso, o gerente tem que sempre estar na posição 1 da sala (o que vai colocar ele na posição 1 da partida).

Isso já acontece quando a sala é criada (porque `Sala.adiciona()` sempre coloca as pessoas no primeiro slot livre, então o jogador que criar a sala - inicialmente o gerente - vai estar na posição 1). O problema é quando ele sai da sala, porque o jogador mais antigo passa a ser o gerente.

O jeito mais fácil de fazer isso foi definir que o gerente não é mais o jogador mais antigo, e sim o jogador na posição 1 (como já acontece no jogo Bluetooth e no single-player). Isso simplifica o código no servidor (não é preciso mais guardar timestamps de entrada em sala, garantir a unicidade deles e consultar pra achar o gerente), o protocolo (não é preciso mais passar a posição do gerente) e o cliente (ele simplesmente assume que o humano é o gerente se ele estiver na posição 1 da sala/partida).