### PR TITLE
Auto-início, confirmação e tipo de sala

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
@@ -37,6 +37,7 @@ public abstract class SalaActivity extends AppCompatActivity {
     protected View layoutBotoesSala;
     protected TextView textViewStatus;
     protected TextView[] textViewsJogadores;
+    protected TextView textViewTituloSala;
     protected TextView textViewInfoSala;
     protected int posJogador;
     protected String modo;
@@ -58,6 +59,7 @@ public abstract class SalaActivity extends AppCompatActivity {
         btnNovaSala = findViewById(R.id.btnNovaSala);
         btnEntrarSala = findViewById(R.id.btnEntrarSala);
         textViewStatus = findViewById(R.id.textViewStatus);
+        textViewTituloSala = findViewById(R.id.textViewTituloSala);
         textViewInfoSala = findViewById(R.id.textViewInfoSala);
         textViewsJogadores = new TextView[4];
         textViewsJogadores[0] = findViewById(R.id.textViewJogador1);
@@ -84,11 +86,18 @@ public abstract class SalaActivity extends AppCompatActivity {
      */
     protected void exibeMesaForaDoJogo(String notificacaoI) {
         runOnUiThread(() -> {
+            // Decodifica a notificação, guardando os dados relevantes
             String[] tokens = notificacaoI.split(" ");
             String[] nomes = tokens[1].split(Pattern.quote("|"));
             modo = tokens[2];
             posJogador = Integer.parseInt(tokens[3]);
             isGerente = posJogador == 1;
+            String tipoSala = tokens[4];
+            String codigo = null;
+            if (tipoSala.startsWith("PRI-")) {
+                tipoSala = "PRI";
+                codigo = tipoSala.substring(4);
+            }
 
             // Volta pra mesa (se já não estiver nela)
             encerraTrucoActivity();
@@ -126,6 +135,17 @@ public abstract class SalaActivity extends AppCompatActivity {
                 } else {
                     setMensagem("Aguardando gerente iniciar partida");
                 }
+            }
+            switch (tipoSala) {
+                case "PUB":
+                    textViewTituloSala.setText("Sala Pública");
+                    break;
+                case "PRI":
+                    textViewTituloSala.setText("Sala Privada");
+                    break;
+                case "BLT":
+                    textViewTituloSala.setText("Bluetooth");
+                    break;
             }
 
             // Tem que ter pelo menos um jogador para deixar o gerente

--- a/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
@@ -33,10 +33,14 @@ public abstract class SalaActivity extends AppCompatActivity {
     protected Button btnTrocar;
     protected Button btnNovaSala;
     protected Button btnEntrarSala;
+    private View layoutJogadoresEBotoesGerente;
     protected View layoutBotoesGerente;
     protected View layoutBotoesSala;
     protected TextView textViewStatus;
-    protected TextView[] textViewsJogadores;
+    protected TextView textViewJogador1;
+    protected TextView textViewJogador2;
+    protected TextView textViewJogador3;
+    protected TextView textViewJogador4;
     protected TextView textViewTituloSala;
     protected TextView textViewInfoSala;
     protected int posJogador;
@@ -51,28 +55,26 @@ public abstract class SalaActivity extends AppCompatActivity {
      */
     protected void inicializaLayoutSala() {
         setContentView(R.layout.sala);
-        layoutBotoesGerente = findViewById(R.id.layoutBotoesGerente);
         btnIniciar = findViewById(R.id.btnIniciar);
         btnInverter = findViewById(R.id.btnInverter);
         btnTrocar = findViewById(R.id.btnTrocar);
+        layoutJogadoresEBotoesGerente = findViewById(R.id.layoutJogadoresEBotoesGerente);
+        layoutBotoesGerente = findViewById(R.id.layoutBotoesGerente);
         layoutBotoesSala = findViewById(R.id.layoutBotoesSala);
         btnNovaSala = findViewById(R.id.btnNovaSala);
         btnEntrarSala = findViewById(R.id.btnEntrarSala);
         textViewStatus = findViewById(R.id.textViewStatus);
         textViewTituloSala = findViewById(R.id.textViewTituloSala);
         textViewInfoSala = findViewById(R.id.textViewInfoSala);
-        textViewsJogadores = new TextView[4];
-        textViewsJogadores[0] = findViewById(R.id.textViewJogador1);
-        textViewsJogadores[1] = findViewById(R.id.textViewJogador2);
-        textViewsJogadores[2] = findViewById(R.id.textViewJogador3);
-        textViewsJogadores[3] = findViewById(R.id.textViewJogador4);
+        textViewJogador1 = findViewById(R.id.textViewJogador1);
+        textViewJogador2 = findViewById(R.id.textViewJogador2);
+        textViewJogador3 = findViewById(R.id.textViewJogador3);
+        textViewJogador4 = findViewById(R.id.textViewJogador4);
+        layoutJogadoresEBotoesGerente.setVisibility(View.GONE);
         layoutBotoesGerente.setVisibility(View.INVISIBLE);
         layoutBotoesSala.setVisibility(View.GONE);
         textViewStatus.setVisibility(View.GONE);
         textViewInfoSala.setVisibility(View.GONE);
-        for (TextView tv : textViewsJogadores) {
-            tv.setText("");
-        }
         setMensagem(null);
     }
 
@@ -117,24 +119,22 @@ public abstract class SalaActivity extends AppCompatActivity {
             // Ajusta os nomes para que o jogador local fique sempre na
             // parte inferior da tela (textViewJogador1)
             int p = (posJogador - 1) % 4;
-            ((TextView) findViewById(R.id.textViewJogador1)).setText(nomes[p]);
+            textViewJogador1.setText(nomes[p]);
             p = (p + 1) % 4;
-            ((TextView) findViewById(R.id.textViewJogador2)).setText(nomes[p]);
+            textViewJogador2.setText(nomes[p]);
             p = (p + 1) % 4;
-            ((TextView) findViewById(R.id.textViewJogador3)).setText(nomes[p]);
+            textViewJogador3.setText(nomes[p]);
             p = (p + 1) % 4;
-            ((TextView) findViewById(R.id.textViewJogador4)).setText(nomes[p]);
+            textViewJogador4.setText(nomes[p]);
 
             // Atualiza outros itens do display
-            ((TextView) findViewById(R.id.textViewStatus)).setText("Modo: " + Partida.textoModo(modo));
+            layoutJogadoresEBotoesGerente.setVisibility(View.VISIBLE);
             findViewById(R.id.layoutBotoesGerente).setVisibility(
                 isGerente ? View.VISIBLE : View.INVISIBLE);
-            if (!isGerente) {
-                if (numJogadores < 4) {
-                    setMensagem("Aguardando mais pessoas ou gerente iniciar partida");
-                } else {
-                    setMensagem("Aguardando gerente iniciar partida");
-                }
+            if (isGerente) {
+                btnIniciar.setEnabled(numJogadores > 1);
+                btnInverter.setEnabled(numJogadores > 1);
+                btnTrocar.setEnabled(numJogadores > 1);
             }
             switch (tipoSala) {
                 case "PUB":
@@ -147,13 +147,12 @@ public abstract class SalaActivity extends AppCompatActivity {
                     textViewTituloSala.setText("Bluetooth");
                     break;
             }
-
-            // Tem que ter pelo menos um jogador para deixar o gerente
-            // iniciar uma partida ou mexer no layout (se não for gerente,
-            // o layout que contém esses botões estará escondido)
-            btnIniciar.setEnabled(numJogadores > 1);
-            btnInverter.setEnabled(numJogadores > 1);
-            btnTrocar.setEnabled(numJogadores > 1);
+            textViewStatus.setText("Modo: " + Partida.textoModo(modo));
+            if (numJogadores < 4) {
+                setMensagem("Aguardando mais pessoas ou gerente iniciar partida");
+            } else {
+                setMensagem("Aguardando gerente iniciar partida");
+            }
         });
     }
 

--- a/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
@@ -4,6 +4,7 @@ import android.app.AlertDialog;
 import android.content.Intent;
 import android.text.Html;
 import android.view.View;
+import android.widget.Button;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -23,6 +24,47 @@ import me.chester.minitruco.core.Partida;
  * essa lógica).
  */
 public abstract class SalaActivity extends AppCompatActivity {
+
+    protected Button btnIniciar;
+    protected Button btnInverter;
+    protected Button btnTrocar;
+    protected Button btnNovaSala;
+    protected Button btnEntrarSala;
+    protected View layoutBotoesGerente;
+    protected View layoutBotoesSala;
+    protected TextView textViewStatus;
+    protected TextView[] textViewsJogadores;
+    protected TextView textViewInfoSala;
+
+    /**
+     * Em salas multiplayer (que de fato mostram uma "sala" com os nomes dos
+     * jogadores, etc.), ativa e inicializa o layout com esses elementos.
+     */
+    protected void inicializaLayoutSala() {
+        setContentView(R.layout.sala);
+        layoutBotoesGerente = findViewById(R.id.layoutBotoesGerente);
+        btnIniciar = findViewById(R.id.btnIniciar);
+        btnInverter = findViewById(R.id.btnInverter);
+        btnTrocar = findViewById(R.id.btnTrocar);
+        layoutBotoesSala = findViewById(R.id.layoutBotoesSala);
+        btnNovaSala = findViewById(R.id.btnNovaSala);
+        btnEntrarSala = findViewById(R.id.btnEntrarSala);
+        textViewStatus = findViewById(R.id.textViewStatus);
+        textViewInfoSala = findViewById(R.id.textViewInfoSala);
+        textViewsJogadores = new TextView[4];
+        textViewsJogadores[0] = findViewById(R.id.textViewJogador1);
+        textViewsJogadores[1] = findViewById(R.id.textViewJogador2);
+        textViewsJogadores[2] = findViewById(R.id.textViewJogador3);
+        textViewsJogadores[3] = findViewById(R.id.textViewJogador4);
+        layoutBotoesGerente.setVisibility(View.INVISIBLE);
+        layoutBotoesSala.setVisibility(View.GONE);
+        textViewStatus.setVisibility(View.GONE);
+        textViewInfoSala.setVisibility(View.GONE);
+        for (TextView tv : textViewsJogadores) {
+            tv.setText("");
+        }
+        setMensagem(null);
+    }
 
     protected void mostraAlertBox(String titulo, String texto) {
         runOnUiThread(() -> {

--- a/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
@@ -3,9 +3,12 @@ package me.chester.minitruco.android;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.text.Html;
+import android.view.View;
+import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import me.chester.minitruco.R;
 import me.chester.minitruco.core.Partida;
 
 /* SPDX-License-Identifier: BSD-3-Clause */
@@ -84,5 +87,24 @@ public abstract class SalaActivity extends AppCompatActivity {
         } catch (InterruptedException e) {
             // não precisa tratar
         }
+    }
+
+    /**
+     * Mostra mensagem permanente em uma caixa no meio da tela.
+     * <p>
+     * Requer layout que contenha textViewMensagem (ex.: sala.xml).
+     *
+     * @param mensagem Mensagem a mostrar, ou null para esconder a caixa
+     */
+    protected void setMensagem(String mensagem) {
+        runOnUiThread(() -> {
+            TextView textViewMensagem = findViewById(R.id.textViewMensagem);
+            if (mensagem == null) {
+                textViewMensagem.setVisibility(View.GONE);
+            } else {
+                textViewMensagem.setVisibility(View.VISIBLE);
+                textViewMensagem.setText(mensagem);
+            }
+        });
     }
 }

--- a/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
@@ -116,11 +116,17 @@ public abstract class SalaActivity extends AppCompatActivity {
             p = (p + 1) % 4;
             ((TextView) findViewById(R.id.textViewJogador4)).setText(nomes[p]);
 
-
             // Atualiza outros itens do display
             ((TextView) findViewById(R.id.textViewStatus)).setText("Modo: " + Partida.textoModo(modo));
             findViewById(R.id.layoutBotoesGerente).setVisibility(
                 isGerente ? View.VISIBLE : View.INVISIBLE);
+            if (!isGerente) {
+                if (numJogadores < 4) {
+                    setMensagem("Aguardando mais pessoas ou gerente iniciar partida");
+                } else {
+                    setMensagem("Aguardando gerente iniciar partida");
+                }
+            }
 
             // Tem que ter pelo menos um jogador para deixar o gerente
             // iniciar uma partida ou mexer no layout (se não for gerente,

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
@@ -83,7 +83,6 @@ public abstract class BluetoothActivity extends SalaActivity implements
     protected Button btnInverter;
     protected Button btnTrocar;
     protected View layoutIniciar;
-    private TextView textViewMensagem;
     private TextView textViewStatus;
     private TextView[] textViewsJogadores;
 
@@ -96,7 +95,6 @@ public abstract class BluetoothActivity extends SalaActivity implements
         btnIniciar = findViewById(R.id.btnIniciarBluetooth);
         btnInverter = findViewById(R.id.btnInverter);
         btnTrocar = findViewById(R.id.btnTrocar);
-        textViewMensagem = findViewById(R.id.textViewMensagem);
         textViewStatus = findViewById(R.id.textViewStatus);
         textViewsJogadores = new TextView[4];
         textViewsJogadores[0] = findViewById(R.id.textViewJogador1);
@@ -171,17 +169,6 @@ public abstract class BluetoothActivity extends SalaActivity implements
             btnIniciar.setEnabled(getNumClientes() > 0);
             btnInverter.setEnabled(getNumClientes() > 0);
             btnTrocar.setEnabled(getNumClientes() > 0);
-        });
-    }
-
-    protected void setMensagem(String mensagem) {
-        runOnUiThread(() -> {
-            if (mensagem == null) {
-                textViewMensagem.setVisibility(View.GONE);
-            } else {
-                textViewMensagem.setVisibility(View.VISIBLE);
-                textViewMensagem.setText(mensagem);
-            }
         });
     }
 

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
@@ -92,7 +92,7 @@ public abstract class BluetoothActivity extends SalaActivity implements
         CriadorDePartida.setActivitySala(this);
         setContentView(R.layout.sala);
         layoutIniciar = findViewById(R.id.layoutIniciar);
-        btnIniciar = findViewById(R.id.btnIniciarBluetooth);
+        btnIniciar = findViewById(R.id.btnIniciar);
         btnInverter = findViewById(R.id.btnInverter);
         btnTrocar = findViewById(R.id.btnTrocar);
         textViewStatus = findViewById(R.id.textViewStatus);

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
@@ -6,9 +6,6 @@ import android.bluetooth.BluetoothAdapter;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
-import android.view.View;
-import android.widget.Button;
-import android.widget.TextView;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -19,7 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import me.chester.minitruco.R;
 import me.chester.minitruco.android.CriadorDePartida;
 import me.chester.minitruco.android.SalaActivity;
 import me.chester.minitruco.core.Partida;
@@ -79,28 +75,13 @@ public abstract class BluetoothActivity extends SalaActivity implements
     protected BluetoothAdapter btAdapter;
     protected final String[] apelidos = new String[4];
     protected String modo;
-    protected Button btnIniciar;
-    protected Button btnInverter;
-    protected Button btnTrocar;
-    protected View layoutIniciar;
-    private TextView textViewStatus;
-    private TextView[] textViewsJogadores;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         CriadorDePartida.setActivitySala(this);
-        setContentView(R.layout.sala);
-        layoutIniciar = findViewById(R.id.layoutIniciar);
-        btnIniciar = findViewById(R.id.btnIniciar);
-        btnInverter = findViewById(R.id.btnInverter);
-        btnTrocar = findViewById(R.id.btnTrocar);
-        textViewStatus = findViewById(R.id.textViewStatus);
-        textViewsJogadores = new TextView[4];
-        textViewsJogadores[0] = findViewById(R.id.textViewJogador1);
-        textViewsJogadores[1] = findViewById(R.id.textViewJogador2);
-        textViewsJogadores[2] = findViewById(R.id.textViewJogador3);
-        textViewsJogadores[3] = findViewById(R.id.textViewJogador4);
+        inicializaLayoutSala();
+
         btAdapter = BluetoothAdapter.getDefaultAdapter();
 
         String[] permissoesFaltantes = permissoesBluetoothFaltantes();

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 
 import me.chester.minitruco.android.CriadorDePartida;
 import me.chester.minitruco.android.SalaActivity;
-import me.chester.minitruco.core.Partida;
 
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright © 2005-2023 Carlos Duarte do Nascimento "Chester" <cd@pobox.com> */
@@ -74,7 +73,6 @@ public abstract class BluetoothActivity extends SalaActivity implements
 
     protected BluetoothAdapter btAdapter;
     protected final String[] apelidos = new String[4];
-    protected String modo;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -138,20 +136,6 @@ public abstract class BluetoothActivity extends SalaActivity implements
      * através da chamada deste método
      */
     abstract void iniciaAtividadeBluetooth();
-
-    protected void atualizaDisplay() {
-        runOnUiThread(() -> {
-            for (int i = 0; i < 4; i++) {
-                textViewsJogadores[i].setText(apelidos[i]);
-            }
-            if (modo != null) {
-                textViewStatus.setText("Modo: " + Partida.textoModo(modo));
-            }
-            btnIniciar.setEnabled(getNumClientes() > 0);
-            btnInverter.setEnabled(getNumClientes() > 0);
-            btnTrocar.setEnabled(getNumClientes() > 0);
-        });
-    }
 
     protected void msgErroFatal(String mensagem) {
         runOnUiThread(() -> {

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ClienteBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ClienteBluetoothActivity.java
@@ -39,11 +39,9 @@ public class ClienteBluetoothActivity extends BluetoothActivity implements
 
     private Thread threadConexao;
     private Thread threadMonitoraConexao;
-    private PartidaRemota partida;
     private BluetoothSocket socket = null;
     private InputStream in;
     private OutputStream out;
-    private int posJogador;
 
     @Override
     void iniciaAtividadeBluetooth() {
@@ -81,7 +79,6 @@ public class ClienteBluetoothActivity extends BluetoothActivity implements
         if (!conectaNoServidor()) {
             return;
         }
-        atualizaDisplay();
 
         if (socket == null) {
             msgErroFatal("Jogo não encontrado. Veja se o seu aparelho está pareado/autorizado com o que criou o jogo e tente novamente.");
@@ -103,10 +100,11 @@ public class ClienteBluetoothActivity extends BluetoothActivity implements
                     if (sbLinha.length() > 0) {
                         LOGGER.log(Level.INFO, "Recebeu:" + sbLinha);
                         char tipoNotificacao = sbLinha.charAt(0);
+                        String notificacao = sbLinha.toString();
                         String parametros = sbLinha.delete(0, 2).toString();
                         switch (tipoNotificacao) {
                         case 'I':
-                            exibeMesaForaDoJogo(parametros);
+                            exibeMesaForaDoJogo(notificacao);
                             break;
                         case 'P':
                             iniciaTrucoActivitySePreciso();
@@ -156,28 +154,6 @@ public class ClienteBluetoothActivity extends BluetoothActivity implements
                 }
             };
             threadMonitoraConexao.start();
-        }
-    }
-
-    private void exibeMesaForaDoJogo(String parametros) {
-        encerraTrucoActivity();
-        if (partida != null) {
-            partida.abandona(0);
-            partida = null;
-        }
-        // Exibe as informações recebidas fora do jogo
-        String[] tokens = parametros.split(" ");
-        String apelidos[] = tokens[0].split("\\|");
-        modo = tokens[1];
-        posJogador = Integer.parseInt(tokens[2]);
-        encaixaApelidosNaMesa(apelidos);
-        LOGGER.log(Level.INFO, "posJogador=" + posJogador);
-        atualizaDisplay();
-    }
-
-    private void encaixaApelidosNaMesa(String[] apelidosOriginais) {
-        for (int n = 1; n <= 4; n++) {
-            apelidos[getPosicaoMesa(n) - 1] = apelidosOriginais[n - 1];
         }
     }
 

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -236,9 +236,10 @@ public class ServidorBluetoothActivity extends BluetoothActivity {
             }
         }
         runOnUiThread(() -> {
-            for (int i = 0; i < 4; i++) {
-                textViewsJogadores[i].setText(apelidos[i]);
-            }
+            textViewJogador1.setText(apelidos[0]);
+            textViewJogador2.setText(apelidos[1]);
+            textViewJogador3.setText(apelidos[2]);
+            textViewJogador4.setText(apelidos[3]);
             if (modo != null) {
                 textViewStatus.setText("Modo: " + Partida.textoModo(modo));
             }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -223,11 +223,10 @@ public class ServidorBluetoothActivity extends BluetoothActivity {
         }
     }
 
-    @Override
     public void atualizaDisplay() {
         // Esse array é usado pelo display para mostrar os nomes dos jogadores
         // TODO: rever isso; de repente a gente deveria atualizar direto ou passar
-        //       ele?
+        //       ele, ainda mais agora que isso só é usado no servidorbluetooth
         apelidos[0] = Jogador.sanitizaNome(btAdapter.getName());
         for(int i = 1; i <= 3; i++) {
             if (jogadores[i - 1] != null) {
@@ -236,7 +235,17 @@ public class ServidorBluetoothActivity extends BluetoothActivity {
                 apelidos[i] = APELIDO_BOT;
             }
         }
-        super.atualizaDisplay();
+        runOnUiThread(() -> {
+            for (int i = 0; i < 4; i++) {
+                textViewsJogadores[i].setText(apelidos[i]);
+            }
+            if (modo != null) {
+                textViewStatus.setText("Modo: " + Partida.textoModo(modo));
+            }
+            btnIniciar.setEnabled(getNumClientes() > 0);
+            btnInverter.setEnabled(getNumClientes() > 0);
+            btnTrocar.setEnabled(getNumClientes() > 0);
+        });
     }
 
     @Override

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -65,7 +65,7 @@ public class ServidorBluetoothActivity extends BluetoothActivity {
                 .getDefaultSharedPreferences(this);
         // TODO titulo poderia passar como extra do intent
         modo = preferences.getString("modo", "P");
-        layoutIniciar.setVisibility(View.VISIBLE);
+        layoutBotoesGerente.setVisibility(View.VISIBLE);
         btnIniciar.setOnClickListener(v -> {
             status = STATUS_EM_JOGO;
             iniciaTrucoActivitySePreciso();

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import me.chester.minitruco.R;
 import me.chester.minitruco.android.JogadorHumano;
 import me.chester.minitruco.core.Jogador;
 import me.chester.minitruco.core.JogadorBot;
@@ -246,6 +247,8 @@ public class ServidorBluetoothActivity extends BluetoothActivity {
             btnIniciar.setEnabled(getNumClientes() > 0);
             btnInverter.setEnabled(getNumClientes() > 0);
             btnTrocar.setEnabled(getNumClientes() > 0);
+            findViewById(R.id.layoutJogadoresEBotoesGerente).setVisibility(View.VISIBLE);
+            layoutBotoesGerente.setVisibility(View.VISIBLE);
         });
     }
 

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -211,9 +211,11 @@ public class ClienteInternetActivity extends SalaActivity {
                 }
             }
 
-            // Tem que ter pelo menos um jogador para deixar o gerente iniciar
-            // TODO decidir se vai ser isso mesmo, ou se aguardamos a sala encher
+            // Tem que ter pelo menos um jogador para deixar o gerente
+            // iniciar uma partida ou mexer no layout
             findViewById(R.id.btnIniciar).setEnabled(numJogadores > 1);
+            findViewById(R.id.btnInverter).setEnabled(numJogadores > 1);
+            findViewById(R.id.btnTrocar).setEnabled(numJogadores > 1);
 
             switch (numJogadores) {
                 case 1:

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -3,7 +3,6 @@ package me.chester.minitruco.android.multiplayer.internet;
 import android.app.AlertDialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.preference.PreferenceManager;
@@ -32,15 +31,11 @@ public class ClienteInternetActivity extends SalaActivity {
 
     private final static Logger LOGGER = Logger.getLogger("ClienteInternetActivity");
 
-    public EditText editNomeJogador;
     private Socket socket;
     private PrintWriter out;
     private BufferedReader in;
     private SharedPreferences preferences;
 
-    private PartidaRemota partida;
-    private String modo;
-    private int posJogador;
     private boolean contagemRegressivaParaIniciar;
 
     @Override

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -213,7 +213,7 @@ public class ClienteInternetActivity extends SalaActivity {
 
             // Atualiza outros itens do display
             ((TextView) findViewById(R.id.textViewStatus)).setText("Modo: " + Partida.textoModo(modo));
-            findViewById(R.id.layoutIniciar).setVisibility(
+            findViewById(R.id.layoutBotoesGerente).setVisibility(
                 isGerente ? View.VISIBLE : View.GONE);
 
             numJogadores = 4;

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -54,7 +54,7 @@ public class ClienteInternetActivity extends SalaActivity {
 
         preferences = PreferenceManager.getDefaultSharedPreferences(this);
         setContentView(R.layout.sala);
-        findViewById(R.id.btnIniciarBluetooth).setOnClickListener(v -> {
+        findViewById(R.id.btnIniciar).setOnClickListener(v -> {
             enviaLinha("Q");
         });
         findViewById(R.id.btnInverter).setOnClickListener(v -> {

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -51,18 +51,7 @@ public class ClienteInternetActivity extends SalaActivity {
         preferences = PreferenceManager.getDefaultSharedPreferences(this);
         inicializaLayoutSala();
         findViewById(R.id.btnIniciar).setOnClickListener(v -> {
-            if (numJogadores == 4) {
-                enviaLinha("Q");
-            } else {
-                new AlertDialog.Builder(this)
-                    .setTitle("Mesa não está cheia")
-                    .setMessage("Você prefere esperar mais gente, ou jogar com bots?")
-                    .setPositiveButton("Jogar", (dialog, which) -> {
-                        enviaLinha("Q");
-                    })
-                    .setNegativeButton("Esperar", null)
-                    .show();
-            }
+            solicitaInicioDeJogoConfirmandoSeTiverBots();
         });
         findViewById(R.id.btnInverter).setOnClickListener(v -> {
             enviaLinha("R I");
@@ -71,6 +60,25 @@ public class ClienteInternetActivity extends SalaActivity {
             enviaLinha("R T");
         });
 
+        iniciaProcessamentoDeNotificacoes();
+    }
+
+    private void solicitaInicioDeJogoConfirmandoSeTiverBots() {
+        if (numJogadores == 4) {
+            enviaLinha("Q");
+        } else {
+            new AlertDialog.Builder(this)
+                .setTitle("Mesa não está cheia")
+                .setMessage("Você prefere esperar mais gente, ou jogar com bots?")
+                .setPositiveButton("Jogar", (dialog, which) -> {
+                    enviaLinha("Q");
+                })
+                .setNegativeButton("Esperar", null)
+                .show();
+        }
+    }
+
+    private void iniciaProcessamentoDeNotificacoes() {
         new Thread(() -> {
             try {
                 if (conecta()) {

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -195,11 +195,11 @@ public class ClienteInternetActivity extends SalaActivity {
         runOnUiThread(() -> {
             switch (numJogadores) {
                 case 1:
-                    setMensagem("Aguardando outra pessoa entrar...");
+                    setMensagem("Aguardando outra pessoa entrar");
                     break;
                 case 2:
                 case 3:
-                    setMensagem("Aguardando mais pessoas...");
+                    setMensagem("Aguardando mais pessoas");
                     break;
                 case 4:
                     // Auto-inicia se a sala estiver cheia (dando um tempo para

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -49,7 +49,7 @@ public class ClienteInternetActivity extends SalaActivity {
         CriadorDePartida.setActivitySala(this);
 
         preferences = PreferenceManager.getDefaultSharedPreferences(this);
-        setContentView(R.layout.sala);
+        inicializaLayoutSala();
         findViewById(R.id.btnIniciar).setOnClickListener(v -> {
             if (numJogadores == 4) {
                 enviaLinha("Q");

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -45,6 +45,7 @@ public class ClienteInternetActivity extends SalaActivity {
     private String modo;
     private int posJogador;
     private boolean contagemRegressivaParaIniciar;
+    private int numJogadores;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -54,7 +55,18 @@ public class ClienteInternetActivity extends SalaActivity {
         preferences = PreferenceManager.getDefaultSharedPreferences(this);
         setContentView(R.layout.sala);
         findViewById(R.id.btnIniciar).setOnClickListener(v -> {
-            enviaLinha("Q");
+            if (numJogadores == 4) {
+                enviaLinha("Q");
+            } else {
+                new AlertDialog.Builder(this)
+                    .setTitle("Mesa não está cheia")
+                    .setMessage("Você prefere esperar mais gente, ou jogar com bots?")
+                    .setPositiveButton("Jogar", (dialog, which) -> {
+                        enviaLinha("Q");
+                    })
+                    .setNegativeButton("Esperar", null)
+                    .show();
+            }
         });
         findViewById(R.id.btnInverter).setOnClickListener(v -> {
             enviaLinha("R I");
@@ -204,7 +216,7 @@ public class ClienteInternetActivity extends SalaActivity {
             findViewById(R.id.layoutIniciar).setVisibility(
                 isGerente ? View.VISIBLE : View.GONE);
 
-            int numJogadores = 4;
+            numJogadores = 4;
             for (String nome : nomes) {
                 if (nome.equals("bot")) {
                     numJogadores--;

--- a/app/src/main/res/drawable/borda_sala.xml
+++ b/app/src/main/res/drawable/borda_sala.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="10dp" />
+    <padding
+        android:bottom="8dp"
+        android:left="8dp"
+        android:right="8dp"
+        android:top="8dp" />
+    <solid android:color="#FF008000" />
+    <stroke
+        android:width="8dp"
+        android:color="#FFB37447" />
+</shape>

--- a/app/src/main/res/layout/sala.xml
+++ b/app/src/main/res/layout/sala.xml
@@ -9,6 +9,7 @@
     tools:ignore="HardcodedText,RtlHardcoded,NestedWeights">
 
     <LinearLayout
+        android:id="@+id/layoutJogadoresEBotoesGerente"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_weight="0"

--- a/app/src/main/res/layout/sala.xml
+++ b/app/src/main/res/layout/sala.xml
@@ -17,6 +17,7 @@
         android:orientation="vertical">
 
         <TextView
+            android:id="@+id/textViewTituloSala"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="#FFB37447"

--- a/app/src/main/res/layout/sala.xml
+++ b/app/src/main/res/layout/sala.xml
@@ -1,39 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    xmlns:tools="http://schemas.android.com/tools"
     android:background="#1B8E3C"
     android:gravity="center"
     android:orientation="vertical"
     tools:ignore="HardcodedText,RtlHardcoded,NestedWeights">
 
-    <FrameLayout
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:layout_weight="1"
-        android:gravity="center">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0"
+        android:background="@drawable/borda_sala"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="#FFB37447"
+            android:gravity="center"
+            android:paddingHorizontal="8dp"
+            android:paddingBottom="2dp"
+            android:text="Bluetooth"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="#FFFFFF"
+            android:textStyle="bold" />
 
         <LinearLayout
             android:id="@+id/layoutJogadores"
             android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal|top"
             android:orientation="vertical">
 
             <TextView
                 android:id="@+id/textViewJogador3"
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_horizontal|top"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal|bottom"
+                android:text="Posição_3"
                 android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textColor="#000000"
+                android:textColor="#FFFFFF"
                 android:textStyle="bold" />
+
 
             <LinearLayout
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
+                android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
                 <TextView
@@ -42,9 +57,39 @@
                     android:layout_height="fill_parent"
                     android:layout_weight="1"
                     android:gravity="left|center_vertical"
+                    android:paddingHorizontal="2dp"
+                    android:text="Posição_4"
                     android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:textColor="#000000"
+                    android:textColor="#FFFFFF"
                     android:textStyle="bold" />
+
+                <LinearLayout
+                    android:id="@+id/layoutBotoesGerente"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <Button
+                        android:id="@+id/btnTrocar"
+                        android:layout_width="170dp"
+                        android:layout_height="wrap_content"
+                        android:text="\u2191 Trocar Parceiro(a)" />
+
+                    <Button
+                        android:id="@+id/btnInverter"
+                        android:layout_width="170dp"
+                        android:layout_height="wrap_content"
+                        android:text="\u2190 Inverter Dupla \u2192" />
+
+                    <Button
+                        android:id="@+id/btnIniciar"
+                        android:layout_width="170dp"
+                        android:layout_height="wrap_content"
+                        android:focusedByDefault="true"
+                        android:text="💬\u00A0JOGAR"
+                        android:textStyle="bold" />
+                </LinearLayout>
+
 
                 <TextView
                     android:id="@+id/textViewJogador2"
@@ -52,70 +97,91 @@
                     android:layout_height="fill_parent"
                     android:layout_weight="1"
                     android:gravity="right|center_vertical"
+                    android:paddingHorizontal="2dp"
+                    android:text="Posição_2"
                     android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:textColor="#000000"
+                    android:textColor="#FFFFFF"
                     android:textStyle="bold" />
             </LinearLayout>
+
 
             <TextView
                 android:id="@+id/textViewJogador1"
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
+                android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:gravity="center_horizontal|bottom"
+                android:gravity="center_horizontal|top"
+                android:paddingBottom="4dp"
+                android:text="Posição_1 (você)"
                 android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textColor="#000000"
+                android:textColor="#FFFFFF"
                 android:textStyle="bold" />
         </LinearLayout>
 
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
-
-            <TextView
-                android:id="@+id/textViewMensagem"
-                android:layout_width="200sp"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:background="@drawable/borda_dialogo"
-                android:gravity="center"
-                android:padding="8dp"
-                android:text="mensagem"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textColor="#FFFFFF"
-                android:textStyle="bold"
-                android:visibility="gone" />
-        </RelativeLayout>
-    </FrameLayout>
+    </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/layoutIniciar"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="0"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
         android:gravity="center"
-        android:orientation="vertical"
-        android:visibility="gone">
+        android:orientation="vertical">
 
-        <Button
-            android:id="@+id/btnTrocar"
-            android:layout_width="220dp"
+        <TextView
+            android:id="@+id/textViewMensagem"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Trocar Parceiro" />
+            android:layout_centerInParent="true"
+            android:layout_marginHorizontal="8dp"
+            android:background="@drawable/borda_dialogo"
+            android:gravity="center"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="6dp"
+            android:text="mensagem que vai ocupar duas linhas"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="#FFFFFF"
+            android:textStyle="bold"
+            android:visibility="visible" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/textViewInfoSala"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="8dp"
+        android:autoSizeMaxTextSize="100dp"
+        android:autoSizeTextType="uniform"
+        android:background="@drawable/borda_modo"
+        android:gravity="center"
+        android:padding="8dp"
+        android:text="Código: 123456\nGerente: joselito"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="#FFFFFF"
+        android:visibility="visible" />
+
+    <LinearLayout
+        android:id="@+id/layoutBotoesSala"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
 
         <Button
-            android:id="@+id/btnInverter"
-            android:layout_width="220dp"
-            android:layout_height="wrap_content"
-            android:text="Inverter Adversários" />
-
-        <Button
-            android:id="@+id/btnIniciar"
-            android:layout_width="220dp"
+            android:id="@+id/btnNovaSala"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:focusedByDefault="true"
-            android:textStyle="bold"
-            android:text="Jogar" />
+            android:text="Trocar de Sala"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/btnEntrarSala"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusedByDefault="true"
+            android:text="Entrar com Código"
+            android:textStyle="bold" />
+
     </LinearLayout>
 
     <LinearLayout

--- a/app/src/main/res/layout/sala.xml
+++ b/app/src/main/res/layout/sala.xml
@@ -110,7 +110,7 @@
             android:text="Inverter Adversários" />
 
         <Button
-            android:id="@+id/btnIniciarBluetooth"
+            android:id="@+id/btnIniciar"
             android:layout_width="220dp"
             android:layout_height="wrap_content"
             android:focusedByDefault="true"


### PR DESCRIPTION
Esse PR inicialmente ia só implementar o auto-início do jogo internet quando a sala está cheia (e a confirmação do início manual quando ela não está), mas foi mais fácil fazer isso consolidando a interpretação da notificação "I" entre os clientes internet e bluetooth, o que motivou melhorar o layout e incluir o tipo da sala junto com os nomes dos jogadores.