### PR TITLE
Aumenta a capacidade de carga do servidor usando Virtual Threads

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 19
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
-        distribution: 'temurin'
+        java-version: '19'
+        distribution: 'oracle'
     - name: Test with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:

--- a/app/src/main/java/me/chester/minitruco/android/OpcoesActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/OpcoesActivity.java
@@ -1,9 +1,11 @@
 package me.chester.minitruco.android;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.PreferenceManager;
 
 import me.chester.minitruco.R;
 
@@ -14,9 +16,31 @@ import me.chester.minitruco.R;
  * Activity que permite configurar manilhas, baralho e outras opções
  */
 public class OpcoesActivity extends AppCompatActivity {
+
+    private SharedPreferences preferences;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.opcoes);
+        preferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+        preferences.registerOnSharedPreferenceChangeListener((sharedPreferences, key) -> {
+            usaServidorDefaultSeVazio(key);
+        });
+    }
+
+    private void usaServidorDefaultSeVazio(String key) {
+        if (key.equals("servidor")) {
+            String original = getString(R.string.opcoes_default_servidor);
+            String atual = preferences.getString("servidor", original);
+            if (atual.trim().isEmpty()) {
+                preferences.edit().putString("servidor", original).apply();
+            } else if (atual.equals("c")) {
+                // Esse é o meu computador, troque pelo seu IP e use "c" para
+                // rapidamente alternar entre o servidor local e o de produçnao
+                preferences.edit().putString("servidor", "192.168.2.10").apply();
+            }
+        }
     }
 }

--- a/app/src/main/java/me/chester/minitruco/android/OpcoesActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/OpcoesActivity.java
@@ -1,11 +1,9 @@
 package me.chester.minitruco.android;
 
-import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.preference.PreferenceManager;
 
 import me.chester.minitruco.R;
 
@@ -16,31 +14,9 @@ import me.chester.minitruco.R;
  * Activity que permite configurar manilhas, baralho e outras opções
  */
 public class OpcoesActivity extends AppCompatActivity {
-
-    private SharedPreferences preferences;
-
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.opcoes);
-        preferences = PreferenceManager.getDefaultSharedPreferences(this);
-
-        preferences.registerOnSharedPreferenceChangeListener((sharedPreferences, key) -> {
-            usaServidorDefaultSeVazio(key);
-        });
-    }
-
-    private void usaServidorDefaultSeVazio(String key) {
-        if (key.equals("servidor")) {
-            String original = getString(R.string.opcoes_default_servidor);
-            String atual = preferences.getString("servidor", original);
-            if (atual.trim().isEmpty()) {
-                preferences.edit().putString("servidor", original).apply();
-            } else if (atual.equals("c")) {
-                // Esse é o meu computador, troque pelo seu IP e use "c" para
-                // rapidamente alternar entre o servidor local e o de produçnao
-                preferences.edit().putString("servidor", "192.168.2.10").apply();
-            }
-        }
     }
 }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -100,7 +100,9 @@ public class ClienteInternetActivity extends SalaActivity {
     }
 
     private boolean conecta() {
-        String servidor = preferences.getString("servidor", this.getString(R.string.opcoes_default_servidor));
+        String servidor = preferences.getBoolean("servidorLocal", false) ?
+            this.getString(R.string.opcoes_default_servidor_local) :
+            this.getString(R.string.opcoes_default_servidor);
         try {
             socket = new Socket();
             socket.connect(new InetSocketAddress(servidor, 6912), 10_000);

--- a/app/src/main/res/values/opcoes.xml
+++ b/app/src/main/res/values/opcoes.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="opcoes_default_servidor">minitruco.chester.me</string>
+    <string name="opcoes_default_servidor_local">192.168.2.10</string>
 
     <string-array name="fonte_nomes">
         <item>Normal</item>

--- a/app/src/main/res/xml/opcoes.xml
+++ b/app/src/main/res/xml/opcoes.xml
@@ -44,10 +44,11 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Desenvolvimento (️☠=PRE-RI-GO, não mexa)">
-        <EditTextPreference
-            android:defaultValue="@string/opcoes_default_servidor"
-            android:key="servidor"
-            android:title="Servidor" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="servidorLocal"
+            android:summary="Usa o servidor local (hardcoded) ao invés do servidor do miniTruco"
+            android:title="Servidor de Desenvolvimento"/>
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="jogoAutomatico"

--- a/core/src/main/java/me/chester/minitruco/core/JogadorBot.java
+++ b/core/src/main/java/me/chester/minitruco/core/JogadorBot.java
@@ -4,6 +4,7 @@ package me.chester.minitruco.core;
 /* Copyright © 2005-2023 Carlos Duarte do Nascimento "Chester" <cd@pobox.com> */
 
 import java.util.Vector;
+import java.util.concurrent.ThreadFactory;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -21,15 +22,26 @@ public class JogadorBot extends Jogador implements Runnable {
     private boolean fingeQuePensa = true;
 
     public JogadorBot() {
-        // TODO se ficarmos com múltiplas estratégias, mover esse sorteio p/ Estrategia
-        this(random.nextBoolean() ? new EstrategiaSellani() : new EstrategiaGasparotto());
+        this(null, null);
     }
 
-    public JogadorBot(Estrategia e) {
-        estrategia = e;
+    public JogadorBot(ThreadFactory tf) {
+        this(null, tf);
+    }
+
+    public JogadorBot(Estrategia e, ThreadFactory tf) {
+        if (e == null) {
+            estrategia = random.nextBoolean() ? new EstrategiaSellani() : new EstrategiaGasparotto();
+        } else {
+            estrategia = e;
+        }
         LOGGER.info("Estrategia: " + estrategia.getClass().getName());
         setNome(APELIDO_BOT);
-        thread = new Thread(this);
+        if (tf == null) {
+            thread = new Thread(this);
+        } else {
+            thread = tf.newThread(this);
+        }
         thread.start();
     }
 

--- a/core/src/test/java/me/chester/minitruco/core/JogadorBotTest.java
+++ b/core/src/test/java/me/chester/minitruco/core/JogadorBotTest.java
@@ -2,10 +2,14 @@ package me.chester.minitruco.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.ThreadFactory;
 
 class JogadorBotTest {
 
@@ -39,7 +43,7 @@ class JogadorBotTest {
             }
         };
         Partida j = new PartidaLocal(false, false, "P");
-        JogadorBot bot = new JogadorBot(e);
+        JogadorBot bot = new JogadorBot(e, null);
         j.adiciona(bot);
         j.adiciona(new JogadorBot());
         j.adiciona(new JogadorBot());
@@ -51,5 +55,17 @@ class JogadorBotTest {
         assertEquals(bot.getCartas()[0], situacaoJogo[0].cartasJogador[0]);
         assertFalse(bot.getCartas()[0] == situacaoJogo[0].cartasJogador[0]);
 
+    }
+
+    @Test
+    void testAceitaThreadFactory() {
+        ThreadFactory tf = spy(new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                return new Thread(r);
+            }
+        });
+        JogadorBot bot = new JogadorBot(tf);
+        verify(tf).newThread(bot);
     }
 }

--- a/docs/documentacao-para-desenvolvimento.md
+++ b/docs/documentacao-para-desenvolvimento.md
@@ -283,21 +283,23 @@ Idealmente isso seria feito serializando as chamadas e objetos com um protocolo 
 
 O protocolo consiste em _comandos_ enviados pelo cliente (ex.: `J 3c` para "`J`ogar o `3` de `c`opas") e _notificações_ enviadas pelo servidor (ex.: `V 2 F` para "`v`ez do jogador na posição `2`, que não pode (`F`alse) jogar fechada). Os clientes devem processar as notificações assincronamente, e podem enviar comandos a qualquer momento, desde que faça sentido (ex.: o comando `J` só funciona se um jogo estiver em andamento e for a vez do jogador).
 
-### Jogando via nc/telnet
+### Testando (jogando) via nc/telnet
 
 Você pode jogar via nc ou telnet. Para isso:
 
 1) Comente a linha `iniciaMonitorDeConexao()` em `JogadorConectado` (senão você vai ter que responder às notificações de keepalive, o que é humanamente muito difícil)
-
 2) Rode o servidor localmente. Você pode fazer isso com `./gradlew :server:run` (ou, em Windows, `gradlew.bat :server:run`). Alternativamente, rode a classe `MiniTrucoServer` no Android Studio.
-
 3) Abra um ou mais terminais e rode `nc localhost 6912` (ou `telnet localhost 6912`). Cada terminal será um jogador.
-
 4) Cada jogador deve se identificar com um nome, enviando um comando `N` (ex.: `N joselito`), entrar em uma sala com as regras desejadas (ex.: `E PUB P`)
-
 5) O gerente (jogador na posição 1 da sala) inicia o jogo com `Q`
-
 6) Dali pra frente é observar as notificações enviadas e os comandos apropriados. Veja a lista completa abaixo.
+
+Você também pode conectar o aplicativo num servidor local (com ou sem keepalive). Os passos são:
+
+1) Colocar o IP do seu computador em `opcoes_default_servidor_local` no arquivo [`/values/opcoes.xml`](/app/src/main/res/values/opcoes.xml)
+2) Rodar o aplicativo num celular ou emulador
+3) Ativar o botão `Opcoes` e ativar o checkbox `Servidor de testes`
+4) Ativer o botão `Internet`.
 
 TODO colocar um exemplo de jogo aqui (GIF ou whatnot)
 

--- a/docs/documentacao-para-desenvolvimento.md
+++ b/docs/documentacao-para-desenvolvimento.md
@@ -90,6 +90,8 @@ O projeto usa o [Gradle](https://gradle.org/) para gerenciamento de dependência
 
 Em princípio, basta abrir o projeto no Android Studio e toda a configuração deve acontecer automaticamente, permitindo executar em dispositivos virtuais ou físicos.
 
+O servidor internet usa Virtual Threads, que são um feature preview; então para rodar ele é preciso baixar um OpenJDK 19 (o 20 não rola porque o Gradle não suporta rodar sob ele) e selecionar como target do Gradle no Android Studio (em Preferences => Build, Execution, Deployment => Build Tools => Gradle). No Mac, se você baixar [daqui](https://jdk.java.net/19/) e colocar sob `/Library/Java/JavaVirtualMachines/OpenJDK/`, ele deve aparecer na lista de targets (além disso, os shims do MacOS também vão achar, se for o JDK mais recente dentro de `/Library/Java/JavaVirtualMachines`, ou seja, `java`, `javac`, `./gradlew` e assemelhados vão encontrar de boa).
+
 Eu recomendo testar em dispositivos físicos mesmo, em particular se for usar Bluetooth (o emulador do Android Studio até simula Bluetooth, mas mas só em versões recentes do Android, e limitado a dois dispositivos), mas é totalmente possível desenvolver sem um.
 
 ### Convenções de código

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,8 @@ android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx2048M
 org.gradle.unsafe.configuration-cache=true
+# server uses Virtual Threads (JEP 436); we need to enable on the compiler...
+android.experimental.enableJavaPreview=true
+# ...and on the VM
+org.gradle.jvmargs=-Xmx2048M --enable-preview

--- a/launcher.sh
+++ b/launcher.sh
@@ -19,7 +19,7 @@ jar="$1"
 servidor_pid=""
 
 inicia_servidor() {
-    java -jar "$jar" &
+    java --enable-preview -jar "$jar" &
     servidor_pid=$! # $! contém o PID do último processo em background
 }
 

--- a/launcher.sh
+++ b/launcher.sh
@@ -39,7 +39,7 @@ servidor_em_execucao() {
 }
 
 aguarda_mudanca_no_jar() {
-    (inotifywait -e modify "$jar") & # em background para não bloquer o SIGTERM
+    (inotifywait -e close_write "$jar") & # em background para não bloquer o SIGTERM
     inotify_pid=$!
     wait $inotify_pid
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:5.3.1'
 }
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_19
+    targetCompatibility = JavaVersion.VERSION_19
 }
 
 test {
@@ -29,4 +29,12 @@ tasks.jar {
     from(project(':core').fileTree("build/classes/java/main")) {
         include '**/*.class'
     }
+}
+
+tasks.withType(JavaExec) {
+    jvmArgs += '--enable-preview'
+}
+
+compileJava {
+    options.compilerArgs += ["--enable-preview"]
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -22,6 +22,7 @@ test {
     testLogging {
         events "passed", "skipped", "failed"
     }
+    jvmArgs += '--enable-preview'
 }
 
 tasks.jar {
@@ -29,6 +30,10 @@ tasks.jar {
     from(project(':core').fileTree("build/classes/java/main")) {
         include '**/*.class'
     }
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs += '--enable-preview'
 }
 
 tasks.withType(JavaExec) {

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -60,7 +60,7 @@ public class JogadorConectado extends Jogador implements Runnable {
      *
      * @param linha linha de texto a enviar
      */
-    public synchronized void println(String linha) {
+    public void println(String linha) {
         out.println(linha);
         out.flush();
         // Não fazemos log de keepalive

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -135,6 +135,12 @@ public class JogadorConectado extends Jogador implements Runnable {
     private void iniciaThreadAuxiliar() {
         Thread threadPrincipal = Thread.currentThread();
         threadMonitorDeConexao = new Thread(() -> {
+            ServerLogger.evento(this, "Aguardando para iniciar monitor de conexão");
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             ServerLogger.evento(this, "Iniciando monitor de conexão");
             boolean avisouQueVaiDesconectarNoFimDaPartida = false;
             while (true) {

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -134,7 +134,7 @@ public class JogadorConectado extends Jogador implements Runnable {
      */
     private void iniciaThreadAuxiliar() {
         Thread threadPrincipal = Thread.currentThread();
-        threadMonitorDeConexao = new Thread(() -> {
+        threadMonitorDeConexao = Thread.ofVirtual().start(() -> {
             ServerLogger.evento(this, "Aguardando para iniciar monitor de conexão");
             try {
                 Thread.sleep(1000);
@@ -175,7 +175,6 @@ public class JogadorConectado extends Jogador implements Runnable {
             ServerLogger.evento(this, "Monitor de conexão finalizado");
             threadMonitorDeConexao = null;
         });
-        threadMonitorDeConexao.start();
     }
 
     private void finalizaThreadAuxiliar() {

--- a/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
+++ b/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
@@ -78,7 +78,7 @@ public class MiniTrucoServer {
                     continue;
                 }
                 JogadorConectado j = new JogadorConectado(sCliente);
-                (new Thread(j)).start();
+                Thread.ofVirtual().start(j);
             }
         } catch (IOException e) {
             ServerLogger.evento(e, "Erro de I/O no ServerSocket");

--- a/server/src/main/java/me/chester/minitruco/server/Sala.java
+++ b/server/src/main/java/me/chester/minitruco/server/Sala.java
@@ -271,7 +271,7 @@ public class Sala {
         int n = 1;
         for (int i = 0; i <= 3; i++) {
             if (jogadores[i] == null) {
-                jogadores[i] = new JogadorBot();
+                jogadores[i] = new JogadorBot(Thread.ofVirtual().factory());
             }
         }
         // Cria a partida com as regras selecionadas, adiciona os jogadores na

--- a/server/src/main/java/me/chester/minitruco/server/Sala.java
+++ b/server/src/main/java/me/chester/minitruco/server/Sala.java
@@ -284,8 +284,7 @@ public class Sala {
             }
 
         }
-        Thread t = new Thread(partida);
-        t.start();
+        Thread.ofVirtual().start(partida);
     }
 
     /**

--- a/server/src/test/java/me/chester/minitruco/server/LoadTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/LoadTest.java
@@ -1,0 +1,47 @@
+package me.chester.minitruco.server;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.Socket;
+
+public class LoadTest {
+    public static void main(String[] args) {
+        String host = "localhost";
+        int porta = 6912;
+
+        int numConexoes = 4096;
+
+        for (int i = 0; i < numConexoes; i++) {
+            new Thread(() -> {
+                try {
+                    Socket socket = new Socket(host, porta);
+                    System.out.println("Conectado " + host + ":" + porta);
+                    PrintWriter out = new PrintWriter(new BufferedWriter(new OutputStreamWriter(
+                            socket.getOutputStream())), true);
+                    BufferedReader in = new BufferedReader(new InputStreamReader(
+                            socket.getInputStream()));
+                    out.println("N robozinho");
+                    out.println("E PUB P");
+                    String linha = in.readLine();
+                    while ((linha = in.readLine()) != null) {
+                        System.out.println("Recebido: " + linha);
+                        if (linha.startsWith("K")) {
+                            out.println(linha);
+                            System.out.println("Mandou keepalive");
+                        } else if (linha.endsWith("1 PUB") && !linha.contains("bot")) {
+                            out.println("Q");
+                        }
+                    }
+
+                    socket.close();
+                } catch (IOException e) {
+                    System.out.println("Erro ao conectar em " + host + ":" + porta + ": " + e.getMessage());
+                }
+            }).start();
+        }
+    }
+}

--- a/server/src/test/java/me/chester/minitruco/server/LoadTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/LoadTest.java
@@ -7,16 +7,25 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.util.HashSet;
+import java.util.Set;
 
 public class LoadTest {
-    public static void main(String[] args) {
-        String host = "localhost";
+    public static void main(String[] args) throws InterruptedException {
+        System.out.println("iniciando LoadTest");
         int porta = 6912;
 
-        int numConexoes = 4096;
+        if (args.length != 2) {
+            System.out.println("passe o servidor e o # de conexões");
+            return;
+        }
+        String host = args[0];
+        int numConexoes = Integer.parseInt(args[1]);
+        Set<Thread> threads = new HashSet<>();
 
         for (int i = 0; i < numConexoes; i++) {
-            new Thread(() -> {
+            Thread.sleep(1);
+            threads.add(Thread.ofVirtual().start(() -> {
                 try {
                     Socket socket = new Socket(host, porta);
                     System.out.println("Conectado " + host + ":" + porta);
@@ -41,7 +50,13 @@ public class LoadTest {
                 } catch (IOException e) {
                     System.out.println("Erro ao conectar em " + host + ":" + porta + ": " + e.getMessage());
                 }
-            }).start();
+            }));
         }
+
+        System.out.println("Todo mundo entrou, agora eles ficam até sair!");
+        for (Thread t : threads) {
+            t.join();
+        }
+        System.out.println("Todos saíram, fim.");
     }
 }


### PR DESCRIPTION
### O problema

Este PR começou com um teste de carga bem inocente (que só abria várias conexões, entrando em salas e inciando o jogo), mas que travou antes mesmo de eu amadurecer ele a ponto de coletar dados.

O motivo: ao contrário do que eu imaginava, threads no Java são sempre 1:1 com threads do sistema operacional desde muito tempo atrás (não existem mais "[green threads](https://en.wikipedia.org/wiki/Green_thread)", como na época em que o app foi criado), e o modelo uma-thread-por-conexão fica muito pesado com threads "reais" (tanto do lado do S.O., que precisa de um tanto de memória e bate em outras limitações, quanto do lado da JVM, porque mesmo sendo um wrapper leve, `Thread` usa espaço no stack, que é mais escasso que o heap.

### Pesquisa

Eu poderia procurar um sistema de asynchronous I/O para as conexões, mas ainda resta o fato de que o core do jogo usa threads (felizmente poucas: uma para a `PartidaLocal`, que é onde a partida roda, e uma para cada `JogadorBot` no jogo - para que os bots respondam de forma independente). Como `PartidaLocal` é um `Runnable` (o código que instancia a  partida é que cria a Thread) e `JogadorBot` pode ser modificado facilmente para receber um `ThreadFactory`, minha motivação foi procurar por sistemas que reimplementem threads de forma parecida com Java old school.

[Kilim](https://github.com/kilim/kilim) e [Quasar](https://github.com/puniverse/quasar) pareciam promissoras, mas não são mantidas há anos. Mas tem o [Project Loom](https://blogs.oracle.com/javamagazine/post/going-inside-javas-project-loom-and-virtual-threads) (detalhes em [JEP-425](https://openjdk.org/jeps/425), seguida por [JEP-436](https://openjdk.org/jeps/436)), que, entre outras coisas, implementa Virtual Threads - e o melhor de tudo, só difere na incialização.

### Implementação

O desafio seria alterar o módulo `server` (que roda no meu servidor Linux e não está em uso atualmente) sem afetar o `app` (a Android que eu tenho que evitar quebrar a todo custo). Mas acabou sendo simples, porque:

- `PartidaLocal` não cria a thread (ao invés disso, ela implementa `Runnable` e deixa isso pro caller, então basta alterar o servidor para usar `Thread.ofVirtual.start(...)` ao invés de `new Thread(...).start()`.
- `JogadorBot` também é um `Runnable`, mas cria sua própria thread. Eu poderia mudar ele para funcionar como `PartidaLocal` - ou até rever se vale mesmo a pena ter uma thread só para fazer ele parecer mais humano e não responder imediatamente, mas o foco aqui é minimizar impacto no código que já está amadurecido, então optei por simplesmente deixar ele receber opcionalmente um `ThreadFactory` na inicialização (revertendo para o comportamento atual de criar a própria thread se não receber). O servidor passa um `Thread.ofVirtual.factory()`, o jogo Android continua como está.

A parte difícil, incrivelmente, foi descobrir como fazer Virtual Threads dar build e rodar. É um feature preview, o que significa que foi preciso:

1) Passar `--enable-preview` em todos os cantos (compilação, testes, execução e deploy).
2) Usar um JDK/JVM que tenha esse feature preview. Eu estava usando [OpenJDK 20](https://jdk.java.net/20/), que até tem, mas o Gradle não roda nela (ele pode usar ela pra compilar, mas se enrosca depois com versão de classes); como tem o Android Studio nessa treta, a solução foi baixar pra OpenJDK 19 de ponta a ponta.

### Riscos

### Riscos

- Não é garantia que esse feature preview vai permancer inalterado (apesar que ele foi do Java 19 para o 20 sem alterar essa parte das Threads, o que é um forte sinal de maturidade), mas como isso é do lado do servidor, eu posso segurar updates indefinidamente e adaptar o que for preciso quando o feature for finalizado.
- O feature preview pode ser descontinuado - novamente, eu seguro na versão atual até pensar em outra coisa
- Talvez ainda assim esse modelo fique pesado - para isso eu vou voltar ao passo original, que era o load test; vide abaixo

### Status e próximos passos

O servidor agora roda melhor (sem OutOfMemory), mas o primeiro teste de load que eu fiz no Mac causou instabilidade. Próximos passos:

- [x] Com a abertura deste draft PR, verificar se é preciso baixar a versão do OpenJDK no CI (Actions) também
- [x] Alterar o [deploy](https://github.com/chesterbr/chester-ansible-configs/blob/main/minitruco.yml) para usar OpenJDK 19 e subir este branch

### Para PRs futuras:

- Melhorar o load test (ver o que cool kids these days usam pra isso; conectar numa velocidade mais compatível com a realidade; tentar jogar automaticamente; coletar uso de memória e saturação)
- Com os valores acima em mãos, implementar um limite de pessoas conectadas 

parte de #38 e #173 