### PR TITLE
Fix soft shutdown e limita jogadores

### DIFF
--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -54,6 +54,17 @@ public class JogadorConectado extends Jogador implements Runnable {
         this.cliente = cliente;
     }
 
+    @FunctionalInterface
+    public interface OnFinishCallback {
+        void execute(Thread thread);
+    }
+
+    private OnFinishCallback onFinishCallback;
+
+    public void setOnFinished(OnFinishCallback onFinishCallback) {
+        this.onFinishCallback = onFinishCallback;
+    }
+
     /**
      * Envia uma linha de texto para o cliente (tipicamente o resultado de um
      * comando, ou um keepalive)
@@ -115,6 +126,9 @@ public class JogadorConectado extends Jogador implements Runnable {
                 ServerLogger.evento(this, "finalizou thread");
             }
             finalizaThreadAuxiliar();
+            if (onFinishCallback != null) {
+                onFinishCallback.execute(Thread.currentThread());
+            }
         }
 
     }

--- a/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
+++ b/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
@@ -23,6 +23,8 @@ public class MiniTrucoServer {
     // Na real é o próximo, mas ok, esse nem tem o botão de internet
     public static final int BUILD_MINIMO_CLIENTE = 20503;
 
+    public static final int MAX_JOGADORES = 1024;
+
     /**
      * Guarda as threads dos jogadores conectados (para que possamos
      * esperar elas finalizarem quando o servidor for desligado).
@@ -86,6 +88,12 @@ public class MiniTrucoServer {
                         break;
                     }
                     // Era só o timeout, vamos continuar
+                    continue;
+                }
+                if (threadsJogadores.size() >= MAX_JOGADORES) {
+                    ServerLogger.evento("Máximo de jogadores (" + MAX_JOGADORES + ") atingido, recusando conexão");
+                    sCliente.getOutputStream().write("! T Servidor lotado, tente novamente mais tarde.\n".getBytes());
+                    sCliente.close();
                     continue;
                 }
                 JogadorConectado j = new JogadorConectado(sCliente);

--- a/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
+++ b/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
@@ -89,8 +89,12 @@ public class MiniTrucoServer {
                     continue;
                 }
                 JogadorConectado j = new JogadorConectado(sCliente);
-                j.setOnFinished((t) -> threadsJogadores.remove(t));
+                j.setOnFinished((t) -> {
+                    threadsJogadores.remove(t);
+                    ServerLogger.evento("Jogadores conectados: " + threadsJogadores.size());
+                });
                 threadsJogadores.add(Thread.ofVirtual().start(j));
+                ServerLogger.evento("Jogadores conectados: " + threadsJogadores.size());
             }
         } catch (IOException e) {
             ServerLogger.evento(e, "Erro de I/O no ServerSocket");

--- a/server/src/test/java/me/chester/minitruco/server/JogadorConectadoTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/JogadorConectadoTest.java
@@ -1,0 +1,46 @@
+package me.chester.minitruco.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+
+class JogadorConectadoTest {
+
+    private Socket mockSocket;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockSocket = mock(Socket.class);
+        when(mockSocket.getInetAddress()).thenReturn(mock(InetAddress.class));
+        when(mockSocket.getInetAddress().getHostAddress()).thenReturn("");
+        when(mockSocket.getInputStream()).thenReturn(mock(InputStream.class));
+        when(mockSocket.getOutputStream()).thenReturn(mock(OutputStream.class));
+    }
+
+    @Test
+    void testOnFinish() throws InterruptedException {
+        JogadorConectado j = new JogadorConectado(mockSocket);
+        Thread t = Thread.ofVirtual().unstarted(j);
+        final boolean[] chamouOnFinished = new boolean[1];
+        chamouOnFinished[0] = false;
+        j.setOnFinished((threadPassadaNoCallback) -> {
+            chamouOnFinished[0] = true;
+            assertEquals(threadPassadaNoCallback, t);
+        });
+        t.start();
+        t.interrupt();
+        t.join();
+        assertTrue(chamouOnFinished[0]);
+    }
+
+}


### PR DESCRIPTION
A introdução de virtual threads (#195) causou um bug interessante: como as threads de `JogadorConectado` não são threads propriamente ditas, a VM não espera elas encerrarem pra dar shutdown, fazendo com que o soft shutdown (#185) falhe (o servidor cai imeditamente ao finalizar a thread que escuta conexões).

Para corrigir isso, foi preciso manter uma collection com as threads de `JogadorConectado` em execução (o que, por sua vez, exigiu que fosse implementado um callback naquela classe para que `MiniTrucoServer` saiba quando um jogador finaliza e tire ele da collection). Quando o listen é interrompido, a thread que escuta as conexões (a única coisa mantendo a JVM no ar nessa hora) espera que não haja mais nenhum jogador conectado antes de encerrar.

Com essa coleção em mãos, ficou fácil implementar dois outros itens de #38: um jeito fácil de ver quantos jogadores estão conectados (bastou logar um evento quando a coleção é modificada: "Jogadores conectados: <tamanho da coleção>", que é facilmente `grep`ável) e um limite do número de jogadores conectados (quando uma conexão entra e a coleção já está no limite daquele tamanho, manda uma notificação toast e desconecta).

Poderia fazer o máximo ser alterável dinamicamente, mas vamos pensar MVP aqui.