### PR TITLE
Elimina gerente (e bots) de salas públicas

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
@@ -160,11 +160,29 @@ public abstract class SalaActivity extends AppCompatActivity {
                     break;
             }
             textViewStatus.setText("Modo: " + Partida.textoModo(modo));
-            if (!isGerente) {
+            // Para atualizar a mensagem, levamos em conta que:
+            // - Salas públicas só iniciam quando estão cheias (e fazem isso
+            //   automaticamente, sem interação do gerente)
+            // - Salas privadas e Bluetooth precisam de pelo menos dois
+            //   jogadores humanos (e o gerente decide quando iniciar)
+            setMensagem(null);
+            if (tipoSala.equals("PUB")) {
+                if (numJogadores < 4) {
+                    setMensagem("Aguardando mais pessoas");
+                }
+            } else if (isGerente) {
+                if (numJogadores == 1) {
+                    setMensagem("Aguardando pelo menos uma pessoa");
+                } else if (numJogadores < 4) {
+                    setMensagem("Aguardando mais pessoas");
+                } else {
+                    setMensagem("Organize as pessoas na mesa e clique em JOGAR!");
+                }
+            } else {
                 if (numJogadores < 4) {
                     setMensagem("Aguardando mais pessoas ou gerente iniciar partida");
                 } else {
-                    setMensagem("Aguardando gerente iniciar partida");
+                    setMensagem("Aguardando gerente organizar a mesa e iniciar partida");
                 }
             }
         });

--- a/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
@@ -53,6 +53,7 @@ public abstract class SalaActivity extends AppCompatActivity {
     protected PartidaRemota partida;
     protected int numJogadores;
     protected boolean isGerente;
+    public String tipoSala;
 
     /**
      * Em salas multiplayer (que de fato mostram uma "sala" com os nomes dos
@@ -104,7 +105,7 @@ public abstract class SalaActivity extends AppCompatActivity {
             modo = tokens[2];
             posJogador = Integer.parseInt(tokens[3]);
             isGerente = posJogador == 1;
-            String tipoSala = tokens[4];
+            tipoSala = tokens[4];
             String codigo = null;
             if (tipoSala.startsWith("PRI-")) {
                 codigo = tipoSala.substring(4);

--- a/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
@@ -138,7 +138,7 @@ public abstract class SalaActivity extends AppCompatActivity {
             layoutJogadoresEBotoesGerente.setVisibility(View.VISIBLE);
             layoutRegras.setVisibility(View.VISIBLE);
             findViewById(R.id.layoutBotoesGerente).setVisibility(
-                isGerente ? View.VISIBLE : View.INVISIBLE);
+                isGerente && !tipoSala.equals("PUB") ? View.VISIBLE : View.INVISIBLE);
             if (isGerente) {
                 btnIniciar.setEnabled(numJogadores > 1);
                 btnInverter.setEnabled(numJogadores > 1);

--- a/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/SalaActivity.java
@@ -1,8 +1,9 @@
 package me.chester.minitruco.android;
 
+import static me.chester.minitruco.core.TrucoUtils.nomeHtmlParaDisplay;
+
 import android.app.AlertDialog;
 import android.content.Intent;
-import android.graphics.Typeface;
 import android.text.Html;
 import android.view.View;
 import android.widget.Button;
@@ -44,6 +45,7 @@ public abstract class SalaActivity extends AppCompatActivity {
     protected TextView textViewJogador2;
     protected TextView textViewJogador3;
     protected TextView textViewJogador4;
+    protected TextView[] textViewsJogadores;
     protected TextView textViewTituloSala;
     protected TextView textViewInfoSala;
     protected int posJogador;
@@ -75,6 +77,9 @@ public abstract class SalaActivity extends AppCompatActivity {
         textViewJogador2 = findViewById(R.id.textViewJogador2);
         textViewJogador3 = findViewById(R.id.textViewJogador3);
         textViewJogador4 = findViewById(R.id.textViewJogador4);
+        textViewsJogadores = new TextView[] {
+            textViewJogador1, textViewJogador2, textViewJogador3, textViewJogador4
+        };
         layoutJogadoresEBotoesGerente.setVisibility(View.INVISIBLE);
         layoutBotoesGerente.setVisibility(View.INVISIBLE);
         layoutBotoesInternet.setVisibility(View.GONE);
@@ -121,21 +126,13 @@ public abstract class SalaActivity extends AppCompatActivity {
                 }
             }
 
-            // Ajusta os nomes para que o jogador local fique sempre na
-            // parte inferior da tela (textViewJogador1), sucedido por
-            // "(você)"; sucede a pessoa que é gerente com "(gerente)"
-            int p = (posJogador - 1) % 4;
-            textViewJogador1.setText(nomes[p] + (p == 0 ? " (você/gerente)" : " (você)"));
-            textViewJogador1.setTypeface(null, p == 0 ? Typeface.BOLD_ITALIC : Typeface.ITALIC);
-            p = (p + 1) % 4;
-            textViewJogador2.setText(nomes[p] + (p == 0 ? " (gerente)" : ""));
-            textViewJogador2.setTypeface(null, p == 0 ? Typeface.BOLD_ITALIC : Typeface.ITALIC);
-            p = (p + 1) % 4;
-            textViewJogador3.setText(nomes[p] + (p == 0 ? " (gerente)" : ""));
-            textViewJogador3.setTypeface(null, p == 0 ? Typeface.BOLD_ITALIC : Typeface.ITALIC);
-            p = (p + 1) % 4;
-            textViewJogador4.setText(nomes[p] + (p == 0 ? " (gerente)" : ""));
-            textViewJogador4.setTypeface(null, p == 0 ? Typeface.BOLD_ITALIC : Typeface.ITALIC);
+            // Coloca os nomes dos jogadores nas posições corretas, indicando
+            // jogador da vez, gerente, expulsáveis
+            for (int i = 1; i <= 4; i++) {
+                String nomeHtml = nomeHtmlParaDisplay(notificacaoI, i);
+                TextView tv = textViewsJogadores[i - 1];
+                tv.setText(Html.fromHtml(nomeHtml));
+            }
 
             // Atualiza outros itens do display
             layoutJogadoresEBotoesGerente.setVisibility(View.VISIBLE);

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/ServidorBluetoothActivity.java
@@ -145,16 +145,13 @@ public class ServidorBluetoothActivity extends BluetoothActivity {
             }
             atualizaClientes();
             if (status == STATUS_LOTADO) {
-                setMensagem(null);
                 sleep(1000);
                 continue;
             }
             pedePraHabilitarDiscoverableSePreciso();
-            setMensagem("Aguardando conexões...");
             // Se chegamos aqui, estamos fora de jogo e com vagas
             try {
                 BluetoothSocket socket = serverSocket.accept();
-                setMensagem(null);
                 if (socket != null) {
                     int slot = encaixaEmUmSlot(socket);
                 }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -285,7 +285,7 @@ public class ClienteInternetActivity extends SalaActivity {
      */
     private void iniciaContagemRegressivaSeMesaCheia() {
         runOnUiThread(() -> {
-            if (numJogadores == 4) {
+            if (numJogadores == 4 && tipoSala.equals("PUB")) {
                 contagemRegressivaParaIniciar = true;
                 new Thread(() -> {
                     for (int i = 3; i > 0; i--) {

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -221,7 +221,7 @@ public class ClienteInternetActivity extends SalaActivity {
                 break;
             case 'I': // Entrou/voltou para uma sala (ou ela foi atualizada)
                 exibeMesaForaDoJogo(line);
-                iniciaContagemRegressivaSeMesaCheia();
+                iniciaContagemRegressivaSeNecessario();
                 break;
             case 'X': // Erro
                 switch(line) {
@@ -277,13 +277,13 @@ public class ClienteInternetActivity extends SalaActivity {
     }
 
     /**
-     * Se a mesa estiver cheia, inicia contagem regressiva para auto-início
-     * do jogo.
+     * Se estivermos numa sala pública e a mesa estiver cheia, inicia contagem
+     * regressiva para auto-início do jogo.
      * <p>
      * Observe que qualquer notificação (exceto o de keepalive) cancela a
      * contagem, e isso é feito no loop de processamento de notificações.
      */
-    private void iniciaContagemRegressivaSeMesaCheia() {
+    private void iniciaContagemRegressivaSeNecessario() {
         runOnUiThread(() -> {
             if (numJogadores == 4 && tipoSala.equals("PUB")) {
                 contagemRegressivaParaIniciar = true;
@@ -295,6 +295,9 @@ public class ClienteInternetActivity extends SalaActivity {
                             return;
                         }
                     }
+                    // Do ponto de vista da UI, salas públicas não têm gerente,
+                    // mas o servidor ainda espera que ele(a) inicie o jogo,
+                    // então...
                     if (isGerente) {
                         enviaLinha("Q");
                     }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -266,7 +266,7 @@ public class ClienteInternetActivity extends SalaActivity {
             comandoTrocaSala.substring(6) : "";
         msgErroFatal("Erro", "Não existe sala " +
             "privada com o código " + codigo + " (ou ela" +
-            "está lotada). " +
+            "está lotada, ou com jogo em andamento). " +
             "Confira o código com a pessoa que te convidou " +
             "e tente novamente.");
     }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -221,7 +221,7 @@ public class ClienteInternetActivity extends SalaActivity {
                 break;
             case 'I': // Entrou/voltou para uma sala (ou ela foi atualizada)
                 exibeMesaForaDoJogo(line);
-                atualizaStatusEContagemRegressiva();
+                iniciaContagemRegressivaSeMesaCheia();
                 break;
             case 'X': // Erro
                 switch(line) {
@@ -282,35 +282,23 @@ public class ClienteInternetActivity extends SalaActivity {
      * <p>
      * Observe que qualquer notificação (exceto o de keepalive) cancela a
      * contagem, e isso é feito no loop de processamento de notificações.
-     * <p>
-     * Em qualquer caso, garante que a mensagem de status reflita a situação.
      */
-    private void atualizaStatusEContagemRegressiva() {
+    private void iniciaContagemRegressivaSeMesaCheia() {
         runOnUiThread(() -> {
-            switch (numJogadores) {
-                case 1:
-                    setMensagem("Aguardando outra pessoa entrar");
-                    break;
-                case 2:
-                case 3:
-                    setMensagem("Aguardando mais pessoas");
-                    break;
-                case 4:
-                    // Auto-inicia se a sala estiver cheia (dando um tempo para
-                    // o gerente organizar ou dar kick de jogadores)
-                    contagemRegressivaParaIniciar = true;
-                    new Thread(() -> {
-                        for (int i = 10; i > 0; i--) {
-                            setMensagem("Mesa completa. Auto-iniciando em " + i);
-                            sleep(1000);
-                            if (!contagemRegressivaParaIniciar) {
-                                return;
-                            }
+            if (numJogadores == 4) {
+                contagemRegressivaParaIniciar = true;
+                new Thread(() -> {
+                    for (int i = 3; i > 0; i--) {
+                        setMensagem("Mesa completa. Auto-iniciando em " + i);
+                        sleep(1000);
+                        if (!contagemRegressivaParaIniciar) {
+                            return;
                         }
-                        if (isGerente) {
-                            enviaLinha("Q");
-                        }
-                    }).start();
+                    }
+                    if (isGerente) {
+                        enviaLinha("Q");
+                    }
+                }).start();
             }
         });
     }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -264,11 +264,11 @@ public class ClienteInternetActivity extends SalaActivity {
     private void erroFatalSalaInvalida() {
         String codigo = comandoTrocaSala.length() > 6 ?
             comandoTrocaSala.substring(6) : "";
-        msgErroFatal("Erro", "Não existe sala " +
-            "privada com o código " + codigo + " (ou ela" +
-            "está lotada, ou com jogo em andamento). " +
-            "Confira o código com a pessoa que te convidou " +
-            "e tente novamente.");
+        msgErroFatal("Erro", "A sala " +
+            "privada com o código " + codigo + " não está aberta. " +
+            "Ela pode estar lotada ou com jogo em andamento, ou " +
+            "ainda, o código pode estar errado. Confira com a pessoa que " +
+            "te convidou e tente novamente.");
     }
 
     @NonNull

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -288,7 +288,7 @@ public class ClienteInternetActivity extends SalaActivity {
             if (numJogadores == 4 && tipoSala.equals("PUB")) {
                 contagemRegressivaParaIniciar = true;
                 new Thread(() -> {
-                    for (int i = 3; i > 0; i--) {
+                    for (int i = 5; i > 0; i--) {
                         setMensagem("Mesa completa. Auto-iniciando em " + i);
                         sleep(1000);
                         if (!contagemRegressivaParaIniciar) {

--- a/app/src/main/res/layout/sala.xml
+++ b/app/src/main/res/layout/sala.xml
@@ -118,7 +118,7 @@
                     android:text="Posição_2 (gerente)"
                     android:textAppearance="?android:attr/textAppearanceMedium"
                     android:textColor="#FFFFFF"
-                    android:textStyle="bold" />
+                    android:textStyle="italic" />
             </LinearLayout>
 
 

--- a/app/src/main/res/layout/sala.xml
+++ b/app/src/main/res/layout/sala.xml
@@ -169,14 +169,6 @@
         android:orientation="horizontal">
 
         <Button
-            android:id="@+id/btnNovaSalaPublica"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:text="Trocar de sala"
-            android:textStyle="bold" />
-
-        <Button
             android:id="@+id/btnNovaSalaPrivada"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -190,6 +182,14 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:text="Entrar com código"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/btnNovaSalaPublica"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="Trocar de sala"
             android:textStyle="bold" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/sala.xml
+++ b/app/src/main/res/layout/sala.xml
@@ -173,7 +173,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:text="Criar sala pública"
+            android:text="Trocar de sala"
             android:textStyle="bold" />
 
         <Button

--- a/app/src/main/res/layout/sala.xml
+++ b/app/src/main/res/layout/sala.xml
@@ -14,9 +14,10 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="8dp"
         android:gravity="center"
-        android:padding="8dp"
-        android:text="Seus amigos podem entrar na sala usando o código abaixo em &quot;Entrar com código&quot;."
+        android:maxLines="2"
+        android:text="Convide pessoas com o código abaixo (elas usam em &quot;Entrar com código&quot;)"
         android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textSize="16sp"
         android:textColor="#FFFFFF"
         android:visibility="visible" />
 
@@ -173,7 +174,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:text="Criar sala privada"
+            android:text="Criar sala\nprivada"
             android:textStyle="bold" />
 
         <Button
@@ -181,7 +182,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:text="Entrar com código"
+            android:text="Entrar com\ncódigo"
             android:textStyle="bold" />
 
         <Button
@@ -189,7 +190,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1"
-            android:text="Trocar de sala"
+            android:text="Trocar\nde sala"
             android:textStyle="bold" />
 
     </LinearLayout>

--- a/core/src/main/java/me/chester/minitruco/core/TrucoUtils.java
+++ b/core/src/main/java/me/chester/minitruco/core/TrucoUtils.java
@@ -49,4 +49,32 @@ public class TrucoUtils {
         return sb.toString();
     }
 
+    private static final int[] POSICAO_GERENTE_PARA_POSICAO_JOGADOR = { 0, 1, 4, 3, 2 };
+
+    /**
+     * Renderiza o HTML para o nome do jogador que vai aparecer naquela posição,
+     * indicando a posição 1 com "(você)", o gerente com "(gerente)" e bold.
+     *
+     * @param notificacaoI notificação da qual vamos tirar os nomes e posições
+     * @param posicaoNaTela qual posição de tela (1=inferior, 2=direita, etc) queremos renderizar
+     * @return String HTML com o nome do jogador e indicacões acima
+     */
+    public static String nomeHtmlParaDisplay(String notificacaoI, int posicaoNaTela) {
+        String[] partes = notificacaoI.split(" ");
+        String[] nomes = partes[1].split("\\|");
+        int posicaoNoJogo = Integer.parseInt(partes[3]);
+        int posicaoGerente = POSICAO_GERENTE_PARA_POSICAO_JOGADOR[posicaoNoJogo];
+        String nome = nomes[(posicaoNoJogo - 1 + posicaoNaTela - 1) % 4];
+        boolean isGerente = (posicaoGerente == posicaoNaTela);
+        boolean isVoce = (posicaoNaTela == 1);
+
+        return new StringBuilder()
+            .append(isGerente ? "<b>" : "")
+            .append(nome)
+            .append(isGerente ? "" : "")
+            .append(isVoce ? " (você)" : "")
+            .append(isGerente ? " (gerente)</b>" : "")
+            .toString();
+    }
+
 }

--- a/core/src/main/java/me/chester/minitruco/core/TrucoUtils.java
+++ b/core/src/main/java/me/chester/minitruco/core/TrucoUtils.java
@@ -62,18 +62,20 @@ public class TrucoUtils {
     public static String nomeHtmlParaDisplay(String notificacaoI, int posicaoNaTela) {
         String[] partes = notificacaoI.split(" ");
         String[] nomes = partes[1].split("\\|");
+        boolean isPublica = partes[4].equals("PUB");
         int posicaoNoJogo = Integer.parseInt(partes[3]);
         int posicaoGerente = POSICAO_GERENTE_PARA_POSICAO_JOGADOR[posicaoNoJogo];
-        String nome = nomes[(posicaoNoJogo - 1 + posicaoNaTela - 1) % 4];
+        int indiceDoNomeNaPosicao = (posicaoNoJogo - 1 + posicaoNaTela - 1) % 4;
         boolean isGerente = (posicaoGerente == posicaoNaTela);
-        boolean isVoce = (posicaoNaTela == 1);
 
+        boolean mostraGerente = isGerente && !isPublica;
+        String nome = nomes[indiceDoNomeNaPosicao];
+        boolean isVoce = (posicaoNaTela == 1);
         return new StringBuilder()
-            .append(isGerente ? "<b>" : "")
+            .append(mostraGerente ? "<b>" : "")
             .append(nome)
-            .append(isGerente ? "" : "")
             .append(isVoce ? " (você)" : "")
-            .append(isGerente ? " (gerente)</b>" : "")
+            .append(mostraGerente ? " (gerente)</b>" : "")
             .toString();
     }
 

--- a/core/src/test/java/me/chester/minitruco/core/TrucoUtilsTest.java
+++ b/core/src/test/java/me/chester/minitruco/core/TrucoUtilsTest.java
@@ -60,23 +60,25 @@ class TrucoUtilsTest {
             String n3 = n.replace(POSICAO_PLACEHOLDER, "3");
             String n4 = n.replace(POSICAO_PLACEHOLDER, "4");
 
-            // Jogador é gerente da sala
+            // Jogador na posição 1 (gerente)
             assertEquals("<b>j1 (você) (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n1, 1));
             assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n1, 2));
             assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n1, 3));
             assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n1, 4));
 
-            // Jogador não é gerente da sala
+            // Jogador na posição 2
             assertEquals("j2 (você)", TrucoUtils.nomeHtmlParaDisplay(n2, 1));
             assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n2, 2));
             assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n2, 3));
             assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n2, 4));
 
+            // Jogador na posição 3
             assertEquals("j3 (você)", TrucoUtils.nomeHtmlParaDisplay(n3, 1));
             assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n3, 2));
             assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n3, 3));
             assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n3, 4));
 
+            // Jogador na posição 4
             assertEquals("j4 (você)", TrucoUtils.nomeHtmlParaDisplay(n4, 1));
             assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n4, 2));
             assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n4, 3));
@@ -92,22 +94,24 @@ class TrucoUtilsTest {
         String n3 = n.replace(POSICAO_PLACEHOLDER, "3");
         String n4 = n.replace(POSICAO_PLACEHOLDER, "4");
 
-        // Jogador é gerente da sala
+        // Jogador na posição 1
         assertEquals("j1 (você)", TrucoUtils.nomeHtmlParaDisplay(n1, 1));
         assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n1, 2));
         assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n1, 3));
         assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n1, 4));
 
-        // Jogador não é gerente da sala
+        // Jogador na posição 2
         assertEquals("j2 (você)", TrucoUtils.nomeHtmlParaDisplay(n2, 1));
         assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n2, 2));
         assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n2, 3));
         assertEquals("j1", TrucoUtils.nomeHtmlParaDisplay(n2, 4));
 
+        // Jogador na posição 3
         assertEquals("j3 (você)", TrucoUtils.nomeHtmlParaDisplay(n3, 1));
         assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n3, 2));
         assertEquals("j1", TrucoUtils.nomeHtmlParaDisplay(n3, 3));
         assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n3, 4));
+
 
         assertEquals("j4 (você)", TrucoUtils.nomeHtmlParaDisplay(n4, 1));
         assertEquals("j1", TrucoUtils.nomeHtmlParaDisplay(n4, 2));

--- a/core/src/test/java/me/chester/minitruco/core/TrucoUtilsTest.java
+++ b/core/src/test/java/me/chester/minitruco/core/TrucoUtilsTest.java
@@ -17,7 +17,7 @@ class TrucoUtilsTest {
 
     @BeforeEach
     void setUp() {
-        nomes = new String[] { "j1", "j2", "j3", "j4" };
+        nomes = new String[]{"j1", "j2", "j3", "j4"};
     }
 
     @Test
@@ -46,13 +46,46 @@ class TrucoUtilsTest {
             when(jogadores[i].getNome()).thenReturn(nomes[i]);
         }
         assertEquals(
-                TrucoUtils.montaNotificacaoI(jogadores, "M", "BLT"),
-                TrucoUtils.montaNotificacaoI(nomes, "M", "BLT")
+            TrucoUtils.montaNotificacaoI(jogadores, "M", "BLT"),
+            TrucoUtils.montaNotificacaoI(nomes, "M", "BLT")
         );
     }
 
     @Test
-    void testNomeParaDisplay() {
+    void testNomeParaDisplayEmSalaPrivadaOuBluetooth() {
+        for (String tipoSala : new String[]{"PRI", "BLT"}) {
+            String n = TrucoUtils.montaNotificacaoI(nomes, "M", tipoSala);
+            String n1 = n.replace(POSICAO_PLACEHOLDER, "1");
+            String n2 = n.replace(POSICAO_PLACEHOLDER, "2");
+            String n3 = n.replace(POSICAO_PLACEHOLDER, "3");
+            String n4 = n.replace(POSICAO_PLACEHOLDER, "4");
+
+            // Jogador é gerente da sala
+            assertEquals("<b>j1 (você) (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n1, 1));
+            assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n1, 2));
+            assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n1, 3));
+            assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n1, 4));
+
+            // Jogador não é gerente da sala
+            assertEquals("j2 (você)", TrucoUtils.nomeHtmlParaDisplay(n2, 1));
+            assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n2, 2));
+            assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n2, 3));
+            assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n2, 4));
+
+            assertEquals("j3 (você)", TrucoUtils.nomeHtmlParaDisplay(n3, 1));
+            assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n3, 2));
+            assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n3, 3));
+            assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n3, 4));
+
+            assertEquals("j4 (você)", TrucoUtils.nomeHtmlParaDisplay(n4, 1));
+            assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n4, 2));
+            assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n4, 3));
+            assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n4, 4));
+        }
+    }
+
+    @Test
+    void testNomeParaDisplayEmSalaPublica() {
         String n = TrucoUtils.montaNotificacaoI(nomes, "M", "PUB");
         String n1 = n.replace(POSICAO_PLACEHOLDER, "1");
         String n2 = n.replace(POSICAO_PLACEHOLDER, "2");
@@ -60,25 +93,25 @@ class TrucoUtilsTest {
         String n4 = n.replace(POSICAO_PLACEHOLDER, "4");
 
         // Jogador é gerente da sala
-        assertEquals("<b>j1 (você) (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n1,1));
-        assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n1,2));
-        assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n1,3));
-        assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n1,4));
+        assertEquals("j1 (você)", TrucoUtils.nomeHtmlParaDisplay(n1, 1));
+        assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n1, 2));
+        assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n1, 3));
+        assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n1, 4));
 
         // Jogador não é gerente da sala
-        assertEquals("j2 (você)", TrucoUtils.nomeHtmlParaDisplay(n2,1));
-        assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n2,2));
-        assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n2,3));
-        assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n2,4));
+        assertEquals("j2 (você)", TrucoUtils.nomeHtmlParaDisplay(n2, 1));
+        assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n2, 2));
+        assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n2, 3));
+        assertEquals("j1", TrucoUtils.nomeHtmlParaDisplay(n2, 4));
 
-        assertEquals("j3 (você)", TrucoUtils.nomeHtmlParaDisplay(n3,1));
-        assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n3,2));
-        assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n3,3));
-        assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n3,4));
+        assertEquals("j3 (você)", TrucoUtils.nomeHtmlParaDisplay(n3, 1));
+        assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n3, 2));
+        assertEquals("j1", TrucoUtils.nomeHtmlParaDisplay(n3, 3));
+        assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n3, 4));
 
-        assertEquals("j4 (você)", TrucoUtils.nomeHtmlParaDisplay(n4,1));
-        assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n4,2));
-        assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n4,3));
-        assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n4,4));
+        assertEquals("j4 (você)", TrucoUtils.nomeHtmlParaDisplay(n4, 1));
+        assertEquals("j1", TrucoUtils.nomeHtmlParaDisplay(n4, 2));
+        assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n4, 3));
+        assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n4, 4));
     }
 }

--- a/core/src/test/java/me/chester/minitruco/core/TrucoUtilsTest.java
+++ b/core/src/test/java/me/chester/minitruco/core/TrucoUtilsTest.java
@@ -3,6 +3,7 @@ package me.chester.minitruco.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static me.chester.minitruco.core.TrucoUtils.POSICAO_PLACEHOLDER;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,5 +49,36 @@ class TrucoUtilsTest {
                 TrucoUtils.montaNotificacaoI(jogadores, "M", "BLT"),
                 TrucoUtils.montaNotificacaoI(nomes, "M", "BLT")
         );
+    }
+
+    @Test
+    void testNomeParaDisplay() {
+        String n = TrucoUtils.montaNotificacaoI(nomes, "M", "PUB");
+        String n1 = n.replace(POSICAO_PLACEHOLDER, "1");
+        String n2 = n.replace(POSICAO_PLACEHOLDER, "2");
+        String n3 = n.replace(POSICAO_PLACEHOLDER, "3");
+        String n4 = n.replace(POSICAO_PLACEHOLDER, "4");
+
+        // Jogador é gerente da sala
+        assertEquals("<b>j1 (você) (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n1,1));
+        assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n1,2));
+        assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n1,3));
+        assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n1,4));
+
+        // Jogador não é gerente da sala
+        assertEquals("j2 (você)", TrucoUtils.nomeHtmlParaDisplay(n2,1));
+        assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n2,2));
+        assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n2,3));
+        assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n2,4));
+
+        assertEquals("j3 (você)", TrucoUtils.nomeHtmlParaDisplay(n3,1));
+        assertEquals("j4", TrucoUtils.nomeHtmlParaDisplay(n3,2));
+        assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n3,3));
+        assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n3,4));
+
+        assertEquals("j4 (você)", TrucoUtils.nomeHtmlParaDisplay(n4,1));
+        assertEquals("<b>j1 (gerente)</b>", TrucoUtils.nomeHtmlParaDisplay(n4,2));
+        assertEquals("j2", TrucoUtils.nomeHtmlParaDisplay(n4,3));
+        assertEquals("j3", TrucoUtils.nomeHtmlParaDisplay(n4,4));
     }
 }


### PR DESCRIPTION
A idéia do kick ficou complicada em termos de UI, então vamos virar o jogo aqui: como ele só é necessário em salas públicas (as privadas e Bluetooth, em princípio, são de amigas/os e você resolve mau comportamento com tapa na oreia mesmo), vamos eliminar o(a) gerente nessas salas (que já auto-iniciam quando cheias, e pouco importa a posição se você só tá jogando com randos na internet mesmo).

Com isso o único abuso possível passa a ser sair do jogo constantemente - mas para isso tem o botão "Trocar de sala" (antigo "Criar sala pública").