### PR TITLE
Melhorias no GET/HEAD de status

### DIFF
--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -128,6 +128,7 @@ public class JogadorConectado extends Jogador implements Runnable {
                     out.println();
                     if (linha.startsWith("HEAD")) {
                         out.flush();
+                        cliente.close();
                         return;
                     }
                     out.println("OK");
@@ -136,6 +137,7 @@ public class JogadorConectado extends Jogador implements Runnable {
                     out.println(MiniTrucoServer.status());
                     out.println();
                     out.flush();
+                    cliente.close();
                     return;
                 }
                 if (("K " + keepAlive).equals(linha)) {

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -113,7 +113,7 @@ public class JogadorConectado extends Jogador implements Runnable {
                     // começar, senão também paciência)
                     finalizaThreadAuxiliar();
                     boolean isGet = linha.startsWith("GET");
-                    boolean isStatus = linha.matches("(GET|HEAD) /status HTTP/.*");
+                    boolean isStatus = linha.matches("^(GET|HEAD) /status(?:\\?\\S*)? HTTP/.*ˆ$");
                     // Espera o cliente mandar todos os headers
                     while (linha != null && !linha.isEmpty()) {
                         linha = in.readLine();

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -111,7 +111,9 @@ public class JogadorConectado extends Jogador implements Runnable {
                 if (linha != null && linha.matches("(GET|HEAD) /status HTTP/.*")) {
                     // Desabilita o monitor de conexão (se o GET chegar antes de ele
                     // começar, senão também paciência)
-                    threadMonitorDeConexao.interrupt();
+                    if (threadMonitorDeConexao != null) {
+                        threadMonitorDeConexao.interrupt();
+                    }
                     LOGGER.info("Status do servidor solicitado (HTTP); enviando e desconectando");
                     out.println("HTTP/1.1 200 OK");
                     out.println("Content-Type: text/plain");

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -114,6 +114,7 @@ public class JogadorConectado extends Jogador implements Runnable {
                     if (threadMonitorDeConexao != null) {
                         threadMonitorDeConexao.interrupt();
                     }
+                    boolean isGet = linha.startsWith("GET");
                     // Espera o cliente mandar todos os headers
                     while (linha != null && !linha.isEmpty()) {
                         linha = in.readLine();
@@ -126,16 +127,13 @@ public class JogadorConectado extends Jogador implements Runnable {
                     out.println("HTTP/1.1 200 OK");
                     out.println("Content-Type: text/plain");
                     out.println();
-                    if (linha.startsWith("HEAD")) {
+                    if (isGet) {
+                        out.println("OK");
                         out.flush();
-                        cliente.close();
-                        return;
-                    }
-                    out.println("OK");
-                    out.flush();
 
-                    out.println(MiniTrucoServer.status());
-                    out.println();
+                        out.println(MiniTrucoServer.status());
+                        out.println();
+                    }
                     out.flush();
                     cliente.close();
                     return;

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -109,9 +109,9 @@ public class JogadorConectado extends Jogador implements Runnable {
                     break;
                 }
                 if (linha != null && linha.matches("^(GET|HEAD) /status HTTP/")) {
-                    // Essa parte (que envia o OK) tem que rodar em menos de 1s,
-                    // para evitar que o keepalive seja enviado antes do header
-                    // HTTP (vide iniciaThreadAuxiliar())
+                    // Desabilita o monitor de conexão (se o GET chegar antes de ele
+                    // começar, senão também paciência)
+                    threadMonitorDeConexao.interrupt();
                     LOGGER.info("Status do servidor solicitado (HTTP); enviando e desconectando");
                     out.println("HTTP/1.1 200 OK");
                     out.println("Content-Type: text/plain");
@@ -179,9 +179,9 @@ public class JogadorConectado extends Jogador implements Runnable {
         threadMonitorDeConexao = Thread.ofVirtual().start(() -> {
             LOGGER.info(this + " Aguardando para iniciar monitor de conexão");
             try {
-                Thread.sleep(1000);
+                Thread.sleep(2000);
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                return;
             }
             LOGGER.info(this + " Iniciando monitor de conexão");
             boolean avisouQueVaiDesconectarNoFimDaPartida = false;

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -114,6 +114,14 @@ public class JogadorConectado extends Jogador implements Runnable {
                     if (threadMonitorDeConexao != null) {
                         threadMonitorDeConexao.interrupt();
                     }
+                    // Espera o cliente mandar todos os headers
+                    while (linha != null && !linha.isEmpty()) {
+                        linha = in.readLine();
+                    }
+                    if (linha == null) {
+                        LOGGER.info("Cliente desconectou antes de mandar headers");
+                        return;
+                    }
                     LOGGER.info("Status do servidor solicitado (HTTP); enviando e desconectando");
                     out.println("HTTP/1.1 200 OK");
                     out.println("Content-Type: text/plain");

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -226,7 +226,6 @@ public class JogadorConectado extends Jogador implements Runnable {
                 }
             }
             LOGGER.info(this + " Monitor de conexão finalizado");
-            threadMonitorDeConexao = null;
         });
     }
 
@@ -234,6 +233,7 @@ public class JogadorConectado extends Jogador implements Runnable {
         if (threadMonitorDeConexao != null) {
             LOGGER.info(this + " Interrompendo monitor de conexão");
             threadMonitorDeConexao.interrupt();
+            threadMonitorDeConexao = null;
         }
     }
 

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -108,7 +108,7 @@ public class JogadorConectado extends Jogador implements Runnable {
                     // Como o SO_TIMEOUT está em zero, podemos assumir desconexão
                     break;
                 }
-                if (linha != null && linha.matches("^(GET|HEAD) /status HTTP/")) {
+                if (linha != null && linha.matches("(GET|HEAD) /status HTTP/.*")) {
                     // Desabilita o monitor de conexão (se o GET chegar antes de ele
                     // começar, senão também paciência)
                     threadMonitorDeConexao.interrupt();
@@ -124,6 +124,7 @@ public class JogadorConectado extends Jogador implements Runnable {
                     out.flush();
 
                     out.println(MiniTrucoServer.status());
+                    out.println();
                     out.flush();
                     return;
                 }

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -108,7 +108,7 @@ public class JogadorConectado extends Jogador implements Runnable {
                     // Como o SO_TIMEOUT está em zero, podemos assumir desconexão
                     break;
                 }
-                if (linha != null && linha.startsWith("GET /status HTTP/")) {
+                if (linha != null && linha.matches("^(GET|HEAD) /status HTTP/")) {
                     // Essa parte (que envia o OK) tem que rodar em menos de 1s,
                     // para evitar que o keepalive seja enviado antes do header
                     // HTTP (vide iniciaThreadAuxiliar())

--- a/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
+++ b/server/src/main/java/me/chester/minitruco/server/JogadorConectado.java
@@ -116,6 +116,10 @@ public class JogadorConectado extends Jogador implements Runnable {
                     out.println("HTTP/1.1 200 OK");
                     out.println("Content-Type: text/plain");
                     out.println();
+                    if (linha.startsWith("HEAD")) {
+                        out.flush();
+                        return;
+                    }
                     out.println("OK");
                     out.flush();
 


### PR DESCRIPTION
Essas mudanças deixam esse apache falsiê mais fortinho:

- Aceita HEAD além de Get (o UptimeRobot usa HEAD no plano "de grátis")
- Ignora parâmetros no request (ex.: `GET /status?rand=nnnn HTTP/1.1`)
- Espera o cliente mandar todos os headers antes de responder (os clientes levam de boa, mas o RFC 2616 pede isso [indiretamente](https://www.rfc-editor.org/rfc/rfc2616#page-39) quando especifica que a resposta deve ser mandada depois que o request for lido e interpretado)
- Explicitamente interrompe a thread de monitoração quando recebe o GET/HEAD e aumenta o tempo de início dela para 2s (ainda vai receber o K nnn se o cliente demorar mais que 2s pra mandar o GET ou HEAD, mas ir além disso quebraria a compatibilidade com os clientes do jogo, não vale a pena)