### PR TITLE
Incentivar pessoas a jogar em salas públicas

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -176,18 +176,7 @@ public class TituloActivity extends SalaActivity {
         }
         if (temInternet) {
             btnInternet.setOnClickListener(v -> {
-                if (!preferences.getBoolean("leuAvisoModoExperimental", false)) {
-                    new AlertDialog.Builder(this).setTitle("AVISO - RECURSO EXPERIMENTAL")
-                        .setIcon(android.R.drawable.ic_dialog_alert)
-                        .setMessage(R.string.aviso_modo_experimental)
-                        .setPositiveButton("Li TUDO e entendi", (dialog, which) -> {
-                            preferences.edit().putBoolean("leuAvisoModoExperimental", true).apply();
-                            pedeNomeEConecta();
-                        })
-                        .show();
-                } else {
-                    pedeNomeEConecta();
-                }
+                pedeNomeEConecta();
             });
         }
     }

--- a/app/src/main/res/layout/sala.xml
+++ b/app/src/main/res/layout/sala.xml
@@ -211,6 +211,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1"
+            android:visibility="gone"
             android:text="Trocar\nde sala"
             android:textStyle="bold" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,13 +219,4 @@
             jogam no mesmo modo e não estão no meio de uma partida para completar.
         ]]>
     </string>
-    <string name="aviso_modo_experimental">Este recurso é experimental - ainda podem ocorrer erros e
-        instabilidades. Ressalto que investi centenas de horas do meu tempo livre e estou cobrindo
-        os custos do servidor, sem qualquer cobrança para vocês.
-        \n\nEm troca, só peço que evitem avaliar negativamente o jogo na loja de aplicativos devido
-        a problemas temporários. Ao invés disso, me informem sobre problemas ou sugestões através
-        do link "entrar em contato".
-        \n\nAgradeço pela compreensão e apoio!
-    </string>
-
 </resources>


### PR DESCRIPTION
Olhando os logs eu vejo que as pessoas dão split muito rápido; este PR

- Temporariamente desabilita o botão "trocar de sala", forçando as pessoas a jogar na mesma (isso era um feature para casos de harassment/mau comportamento, mas na prática está dificultando a formação de salas, vamos ver se ele vai ser mesmo necessário)
- Tira o anúncio de feature experimental