### PR TITLE
Introduz o modo "vale 1 ponto"

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/PreferenceUtils.java
+++ b/app/src/main/java/me/chester/minitruco/android/PreferenceUtils.java
@@ -11,12 +11,20 @@ import androidx.preference.PreferenceManager;
 import me.chester.minitruco.R;
 
 public class PreferenceUtils {
+    public static Boolean isServidorLocal(Context context) {
+        return getPreferences(context).getBoolean("servidorLocal", false);
+    }
+
+    public static Boolean valeUm(Context context) {
+        return getPreferences(context).getBoolean("valeUm", false);
+    }
+
     public static String getLetraDoModo(Context context) {
         return getPreferences(context).getString("modo", "P");
     }
 
     public static String getServidor(Context context) {
-        return getPreferences(context).getBoolean("servidorLocal", false) ?
+        return isServidorLocal(context) ?
             context.getString(R.string.opcoes_default_servidor_local) :
             context.getString(R.string.opcoes_default_servidor);
     }

--- a/app/src/main/java/me/chester/minitruco/android/PreferenceUtils.java
+++ b/app/src/main/java/me/chester/minitruco/android/PreferenceUtils.java
@@ -15,7 +15,7 @@ public class PreferenceUtils {
         return getPreferences(context).getBoolean("servidorLocal", false);
     }
 
-    public static Boolean valeUm(Context context) {
+    public static Boolean isValeUm(Context context) {
         return getPreferences(context).getBoolean("valeUm", false);
     }
 

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -362,6 +362,9 @@ public class TituloActivity extends SalaActivity {
     @Override
     public Partida criaNovaPartida(JogadorHumano jogadorHumano) {
         String modo = getLetraDoModo(this);
+        if (preferences.getBoolean("valeUm", false)) {
+            modo = "1";
+        }
         boolean humanoDecide = preferences.getBoolean("humanoDecide", true);
         boolean jogoAutomatico = preferences.getBoolean("jogoAutomatico", false);
         Partida novaPartida = new PartidaLocal(humanoDecide, jogoAutomatico, modo);

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -362,7 +362,7 @@ public class TituloActivity extends SalaActivity {
     @Override
     public Partida criaNovaPartida(JogadorHumano jogadorHumano) {
         String modo = getLetraDoModo(this);
-        if (preferences.getBoolean("valeUm", false)) {
+        if (PreferenceUtils.valeUm(this)) {
             modo = "1";
         }
         boolean humanoDecide = preferences.getBoolean("humanoDecide", true);

--- a/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/TituloActivity.java
@@ -362,7 +362,7 @@ public class TituloActivity extends SalaActivity {
     @Override
     public Partida criaNovaPartida(JogadorHumano jogadorHumano) {
         String modo = getLetraDoModo(this);
-        if (PreferenceUtils.valeUm(this)) {
+        if (PreferenceUtils.isValeUm(this)) {
             modo = "1";
         }
         boolean humanoDecide = preferences.getBoolean("humanoDecide", true);

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -232,7 +232,7 @@ public class ClienteInternetActivity extends SalaActivity {
             case 'N': // Nome foi aceito
                 // Caso as configurações de desenvolvimento sejam para usar o
                 // servidor local, respeita a opção de valer 1 ponto
-                if (PreferenceUtils.isServidorLocal(this) && PreferenceUtils.valeUm(this)) {
+                if (PreferenceUtils.isServidorLocal(this) && PreferenceUtils.isValeUm(this)) {
                     enviaLinha("E PUB 1");
                     break;
                 }

--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/internet/ClienteInternetActivity.java
@@ -1,7 +1,6 @@
 package me.chester.minitruco.android.multiplayer.internet;
 
 import static android.text.InputType.TYPE_CLASS_NUMBER;
-
 import static me.chester.minitruco.android.PreferenceUtils.getLetraDoModo;
 import static me.chester.minitruco.android.PreferenceUtils.getServidor;
 
@@ -31,6 +30,7 @@ import java.util.logging.Logger;
 import me.chester.minitruco.BuildConfig;
 import me.chester.minitruco.android.CriadorDePartida;
 import me.chester.minitruco.android.JogadorHumano;
+import me.chester.minitruco.android.PreferenceUtils;
 import me.chester.minitruco.android.SalaActivity;
 import me.chester.minitruco.android.TrucoActivity;
 import me.chester.minitruco.android.multiplayer.PartidaRemota;
@@ -230,6 +230,12 @@ public class ClienteInternetActivity extends SalaActivity {
         }
         switch (line.charAt(0)) {
             case 'N': // Nome foi aceito
+                // Caso as configurações de desenvolvimento sejam para usar o
+                // servidor local, respeita a opção de valer 1 ponto
+                if (PreferenceUtils.isServidorLocal(this) && PreferenceUtils.valeUm(this)) {
+                    enviaLinha("E PUB 1");
+                    break;
+                }
                 // Já vamos entrar de cara numa sala pública (se a pessoa quiser
                 // fazer outra coisa, ela usa o botão apropriado)
                 enviaLinha("E PUB " + getLetraDoModo(this));

--- a/app/src/main/res/xml/opcoes.xml
+++ b/app/src/main/res/xml/opcoes.xml
@@ -59,5 +59,10 @@
             android:key="jogoAutomatico"
             android:summary="Joga uma carta ou pede truco automaticamente (e aleatoriamente) apenas em jogo local"
             android:title="Jogo Automático" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="valeUm"
+            android:summary="Ignora o modo selecionado e faz a partida valer um ponto só com a regra do Paulista"
+            android:title="Vale 1" />
     </PreferenceCategory>
 </androidx.preference.PreferenceScreen>

--- a/core/src/main/java/me/chester/minitruco/core/Modo.java
+++ b/core/src/main/java/me/chester/minitruco/core/Modo.java
@@ -26,6 +26,8 @@ public interface Modo {
                 return new ModoManilhaVelha();
             case "L":
                 return new ModoBaralhoLimpo();
+            case "1":
+                return new ModoFinalizaEm1();
             default:
                 throw new IllegalArgumentException("Modo deve ser M, P, V ou L");
         }

--- a/core/src/main/java/me/chester/minitruco/core/ModoFinalizaEm1.java
+++ b/core/src/main/java/me/chester/minitruco/core/ModoFinalizaEm1.java
@@ -1,0 +1,13 @@
+package me.chester.minitruco.core;
+
+/**
+ * Modo de jogo igual ao Paulista, mas a partida termina em 1 ponto.
+ * <p>
+ * APENAS PARA TESTES
+ */
+public class ModoFinalizaEm1 extends ModoPaulista {
+
+    public int pontuacaoParaMaoDeX() {
+        return 0;
+    }
+}

--- a/core/src/main/java/me/chester/minitruco/core/Partida.java
+++ b/core/src/main/java/me/chester/minitruco/core/Partida.java
@@ -117,6 +117,7 @@ public abstract class Partida implements Runnable {
             case "M": return "Truco Mineiro";
             case "L": return "Baralho Limpo";
             case "V": return "Manilha Velha";
+            case "1": return "DEBUG: Finaliza em 1";
         }
         return null;
     }


### PR DESCRIPTION
Este modo funciona igual ao Paulista, mas a partida só vale 1 ponto (e portanto não aceita truco).

Ele é útil para debug de ações que acontecem no final da partida, tanto em testes manuais, quanto em testes automáticos.

Não pode ser selecionado na UI normal; ao invés disso, tem que ser habilitado por uma opção de desenvolvimento, e só vale para jogo local ou para jogo em servidor local

(talvez seja interessante habilitar para o Bluetooth no futuro)

Implementa boa parte de #246 (sem os refactorings), foi feita pra desbloquear #245