### PR TITLE
Encerra salas somente com bots

### DIFF
--- a/server/src/main/java/me/chester/minitruco/server/Sala.java
+++ b/server/src/main/java/me/chester/minitruco/server/Sala.java
@@ -370,6 +370,7 @@ public class Sala {
 
         }
         Thread.ofVirtual().start(partida);
+        atualizaColecoesDeSalas();
     }
 
     /**

--- a/server/src/test/java/me/chester/minitruco/server/SalaTest.java
+++ b/server/src/test/java/me/chester/minitruco/server/SalaTest.java
@@ -236,6 +236,22 @@ class SalaTest {
         s.iniciaPartida(j1);
     }
 
+    @Test
+    void testModosAguardandoJogadoresSoConsideraSalaComVaga() {
+        assertEquals("", Sala.modosAguardandoJogadores());
+        Sala s = new Sala(true, "P");
+        s.adiciona(j1);
+        assertEquals("P", Sala.modosAguardandoJogadores());
+        s.adiciona(j2);
+        assertEquals("P", Sala.modosAguardandoJogadores());
+        s.iniciaPartida(j1);
+        assertEquals("", Sala.modosAguardandoJogadores());
+        Comando.interpreta("A", j1); // Troca por bot
+        assertEquals("", Sala.modosAguardandoJogadores());
+        Comando.interpreta("A", j2); // Troca por bot, sala vazia
+        assertEquals("", Sala.modosAguardandoJogadores());
+    }
+
    @Test
    void testSalaNaoIniciaPartidaSozinha() {
         Sala s = new Sala(true, "P");


### PR DESCRIPTION
Isso deve resolver #252 ; já que foi verificado que um bot crashando entra em loop, reporta a sala como disponível quando ela não fica:

```
14126@ubuntu-2023 2024-02-21 19:20:24 [INFO] JogadorBot.run: Erro em joga
Exception: java.lang.ArrayIndexOutOfBoundsException
14126@ubuntu-2023 2024-02-21 19:20:24 [INFO] JogadorBot.run: Out Of Bounds tentando recuperar a carta de cartasRestantes
Exception: java.lang.ArrayIndexOutOfBoundsException: 0 >= 0
	at java.base/java.util.Vector.elementAt(Vector.java:466)
	at me.chester.minitruco.core.JogadorBot.run(JogadorBot.java:163)
	at java.base/java.lang.Thread.run(Thread.java:1583)
14126@ubuntu-2023 2024-02-21 19:20:24 [INFO] JogadorBot.run: Erro em joga
Exception: java.lang.ArrayIndexOutOfBoundsException
14126@ubuntu-2023 2024-02-21 19:20:24 [INFO] JogadorBot.run: Out Of Bounds tentando recuperar a carta de cartasRestantes
Exception: java.lang.ArrayIndexOutOfBoundsException: 0 >= 0
	at java.base/java.util.Vector.elementAt(Vector.java:466)
	at me.chester.minitruco.core.JogadorBot.run(JogadorBot.java:163)
	at java.base/java.lang.Thread.run(Thread.java:1583)
...
```