### PR TITLE
Evita deixar threads "presas" no servidor

### DIFF
--- a/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
+++ b/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
@@ -9,6 +9,7 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -43,7 +44,7 @@ public class MiniTrucoServer {
      * Guarda as threads dos jogadores conectados (para que possamos
      * esperar elas finalizarem quando o servidor for desligado).
      */
-    private static Set<Thread> threadsJogadores = new HashSet<>();
+    private static Set<Thread> threadsJogadores = ConcurrentHashMap.newKeySet();
 
     /**
      * Ponto de entrada do servidor. Apenas dispara a thread que aceita

--- a/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
+++ b/server/src/main/java/me/chester/minitruco/server/MiniTrucoServer.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Handler;
@@ -114,10 +113,12 @@ public class MiniTrucoServer {
                 JogadorConectado j = new JogadorConectado(sCliente);
                 j.setOnFinished((t) -> {
                     threadsJogadores.remove(t);
-                    LOGGER.info("Jogadores conectados: " + threadsJogadores.size());
+                    LOGGER.info("Thread removida da coleção. Jogadores conectados: " + threadsJogadores.size());
                 });
-                threadsJogadores.add(Thread.ofVirtual().name(j.getNome()).start(j));
-                LOGGER.info("Jogadores conectados: " + threadsJogadores.size());
+                Thread t = Thread.ofVirtual().name(j.getNome()).unstarted(j);
+                threadsJogadores.add(t);
+                LOGGER.info("Thread adicionada na coleção. Jogadores conectados: " + threadsJogadores.size());
+                t.start();
             }
         } catch (IOException e) {
             LOGGER.log(Level.INFO, "Erro de I/O no ServerSocket", e);


### PR DESCRIPTION
Muito ocasionalmente uma thread de jogador ficava "presa" na coleção `ThreadsJogadores`. Isso não causava grandes problemas porque a thread era sempre de uma conexão já finalizada, e o servidor provavelmente seria reiniciado antes de atingir o limite de threads ativas programado (1024).

Não sei se foi a atualização do OpenJDK, do sistema operacional ou de alguma característica de virtualização, mas ao mudar de provedor, isso começou a acontecer uma vez a cada poucos segundos, o que eventualmente faz o servidor atingir o limite de threads e não deixa mais ninguém entrar.

A princípio achei que era alguma questão de rede no novo servidor, mas vi que era possível reproduzir fazendo várias chamadas simultâneas à página de status diretamente do servidor, praticamente sem envolver a rede (ex.: com umas 10x de `curl localhost:6912 & curl localhost:6912 & curl localhost:6912 & ...`) e observando o status (`ONLINE <n>`).

Uma revisão do código revelou dois problemas:

1) Eu estava usando [`HashSet`](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html) para guardar a lista de threads, e essa coleção não é thread-safe. Isso normalmente não seria um problema, mas a thread é removida da conexão no evento `JogadorConectado.onFinish`, então pode rolar mais de uma remoção simultaneamente.

Eu poderia sincronizar com algum objeto, mas achei mais fácil trocar pelo drop-in replacement [`ConcurrentHashMap`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html). Isso não solucionou o problema, mas estava atrapalhando o diagnóstico (e poderia ter outras consequências aleatórias, vide documentação do HashSet)

2) Eu estava adicionando a thread na lista depois de iniciá-la. Em chamadas muito rápidas (ex.: a de status) isso torna possível remover a thread da lista antes de adicioná-la - na prática a remoção não fará nada, e a thread será adicionada e ficará lá para sempre. Essa é provavelmente a causa raiz do problema, e ao corrigir isso não é possível mais reproduzir manualmente.