### PR TITLE
Upgrade Android Gradle Plugin to 8.13.2 and Gradle to 8.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.13.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Upgrades Android Gradle Plugin from 8.2.0 to 8.13.2
- Upgrades Gradle wrapper from 8.4 to 8.13

## Test plan
- [x] Ran gradle plugin upgrade assistant
- [x] Verified build works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)