### PR TITLE
Finish Bluetooth activity if permission revoked while backgrounded

### DIFF
--- a/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
+++ b/app/src/main/java/me/chester/minitruco/android/multiplayer/bluetooth/BluetoothActivity.java
@@ -92,6 +92,9 @@ public abstract class BluetoothActivity extends SalaActivity implements
     protected void onResume() {
         super.onResume();
         CriadorDePartida.setActivitySala(this);
+        if (permissoesBluetoothFaltantes().length > 0) {
+            finish();
+        }
     }
 
     private String[] permissoesBluetoothFaltantes() {


### PR DESCRIPTION
Fixes #265

## What

Adds a permission re-check in `BluetoothActivity.onResume()`. If `BLUETOOTH_CONNECT` (or any other required Bluetooth permission) has been revoked while the app was in the background, the activity calls `finish()` before any Bluetooth calls can run.

## Why

`onCreate()` already checks permissions and only proceeds if they are granted. However, `onResume()` did not re-verify, so returning from the background with a revoked permission led to a `SecurityException` crash — most visibly in `ServidorBluetoothActivity.atualizaClientes()` (called 4s after `onResume()` via `postDelayed`), and potentially in `ClienteBluetoothActivity.listaDispositivosPareados()` as well.

Fixing it in the base class covers both subclasses without duplicating logic.